### PR TITLE
Add JSON schemas and validation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include *.txt LICENSE tox.ini .coveragerc *.rst *.toml.example OWNERS
-recursive-include gordon *.py
+recursive-include gordon *.py *.json
 recursive-include tests *.py
 
 # Exclude service-specific config

--- a/gordon/exceptions.py
+++ b/gordon/exceptions.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class GordonError(Exception):
+    """General Gordon Application Error."""
+
+
+class GordonJsonValidationError(GordonError):
+    """An error validating JSON."""

--- a/gordon/schema/__init__.py
+++ b/gordon/schema/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/gordon/schema/definitions/google-audit-log.json
+++ b/gordon/schema/definitions/google-audit-log.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+
+  "title": "Google Audit Log",
+  "description" : "Schema for parsing Google Audit Log messages.",
+  "properties": {
+    "methodName": {
+      "type": "string",
+      "required": true,
+      "description": "Action performed on GCP instance.",
+      "enum": ["v1.compute.instances.insert", "v1.compute.instances.delete"]
+    },
+    "resourceName": {
+      "type": "string",
+      "required": true,
+      "description": "REST name for instance, containing project and zone.",
+      "examples": [
+        "/projects/a-project-name/zones/a-zone-name/instances/an-instance-name"
+      ]
+    }
+  }
+}

--- a/gordon/schema/definitions/record-action.json
+++ b/gordon/schema/definitions/record-action.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+
+  "title": "An action to perform on a DNS record.",
+  "description" : "Schema for creating or deleting selected DNS records.",
+  "properties": {
+    "name": {
+      "type": "string",
+      "required": true,
+      "examples": [
+        "fully-qualified-instance-name-1234.subdomain.example.com",
+        "www.example.com"
+      ]
+    },
+    "target": {
+      "type": "string",
+      "required": true,
+      "examples": [
+        "192.168.0.1",
+        "some-other-domain.example.com",
+        "some text value"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "enum": ["A", "CNAME", "PTR", "TXT"],
+      "default": "A"
+    },
+    "action": {
+      "type": "string",
+      "enum": ["create", "delete"],
+      "default": "create"
+    }
+  }
+}

--- a/gordon/schema/validate.py
+++ b/gordon/schema/validate.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from pathlib import Path
+
+import jsonschema
+
+
+from gordon import exceptions
+
+DEF_DIR = Path(os.path.dirname(__file__), 'definitions').absolute()
+
+
+class JsonValidator(object):
+
+    def __init__(self):
+        """Initialize known schemas from files into reference dict."""
+        self.schemas = {}
+        for jsonfile in DEF_DIR.glob('*.json'):
+            with open(jsonfile) as definition:
+                self.schemas[jsonfile.stem] = json.loads(definition.read())
+
+    def validate(self, json_dict, schema):
+        """Validate supplied JSON object against a known schema.
+
+        Args:
+            json_dict (dict): a dict representation of the JSON object
+            schema (str): name of the schema
+
+        Raises:
+            GordonJsonValidationError if JSON is invalid or cannot be validated
+        """
+        try:
+            jsonschema.validate(json_dict, self.schemas[schema])
+            return
+        except KeyError:
+            err = f'Schema not found (available: {list(self.schemas)})'
+        except jsonschema.ValidationError as e:
+            err = f'JSON schema was invalid: {e}'
+        raise exceptions.GordonJsonValidationError(err)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==6.7
 toml==0.9.3.1
 ulogger==1.0.1
+jsonschema==2.6.0

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from gordon import exceptions
+from gordon.schema.validate import JsonValidator
+
+
+@pytest.fixture(scope='session')
+def validator():
+    return JsonValidator()
+
+
+valid_audit_log = {
+    'methodName': 'v1.compute.instances.insert',
+    'resourceName': '/projects/project-a/zones/zone-b/instances/vm-abc'
+}
+valid_record_a = {
+    'name': 'test1-hostname-a1.subdomain.example.com',
+    'target': '10.0.0.1'
+}
+valid_record_cname = {
+    'name': 'some_domain.example.com',
+    'target': 'some_other_name.somewhere.else.com',
+    'type': 'CNAME',
+    'action': 'create'
+}
+
+
+@pytest.mark.parametrize('valid_json,name', [
+    (valid_audit_log, 'google-audit-log'),
+    (valid_record_a, 'record-action'),
+    (valid_record_cname, 'record-action')
+])
+def test_json_validator_success(validator, valid_json, name):
+    """Validates against multiple valid inputs."""
+    # No need to assert, since exception will raise on failure
+    validator.validate(valid_json, name)
+
+
+@pytest.mark.parametrize('invalid_json', [{'bad': 'json'}, '{"bad": "dict"}'])
+def test_json_validator_raises_on_invalid_data(validator, invalid_json):
+    """Raise exception when supplied with anything that doesn't match schema."""
+    with pytest.raises(exceptions.GordonJsonValidationError) as e:
+        assert validator.validate(invalid_json, 'record-action')
+    assert 'JSON schema was invalid' in str(e.value)
+
+
+def test_json_validator_raises_on_schema_not_found(validator):
+    """Raise exception when attempting validation against unknown schema."""
+    with pytest.raises(exceptions.GordonJsonValidationError) as e:
+        assert validator.validate({}, 'fake-schema-name')
+    expected = f'Schema not found (available: {list(validator.schemas)})'
+    assert expected == str(e.value)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <TODO: LINK TO CONTRIBUTING.MD>  // is this necessary since github refers to it when opening a pull request?
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
3. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This PR adds defined schemas for the messages Gordon will receive over PubSub and corresponding validation logic.

**Special notes for your reviewer**:
I chose to create two message types.  One is for the audit log messages we receive from Google, and the other is a more generic record + action combination that could be sent by the Gordon reconciliation "janitor" or a hook where records are manually input. I chose only to accept a limited amount of DNS record types for this first iteration, based on what are most commonly input manually and that have a format that can be easily summarized with name and target only.

I chose to make it a module so it could also be imported separately on the publishing side to verify messages before sending them out. Ideally I'd like to have it as a separate package to be dependency of both the publisher and the subscriber, without having to depend on the full Gordon package, but I decided to move ahead with an MVP of a submodule first. I updated the MANIFEST.in to accept the JSON files for this purpose, but I don't have a lot of experience here to know if that is all that is needed.  

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds defined JSON schemas and validation for initial PubSub message types that Gordon will receive.
```
