### PR TITLE
Add ability to discover 3rd-party plugins

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,3 +12,10 @@ main
 
 .. autofunction:: gordon.main.setup
 
+
+plugins_loader
+--------------
+
+.. automodule:: gordon.plugins_loader
+
+.. autofunction:: gordon.plugins_loader.load_plugins

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -18,6 +18,9 @@ You may choose to have a ``gordon-user.toml`` file for development. Any top-leve
 
 .. code-block:: ini
 
+    [core]
+    debug = true
+
     [core.logging]
     level = "debug"
     handlers = ["stream"]
@@ -36,6 +39,14 @@ core
     Plugins that the Gordon service needs to load. If a plugin is not listed, Gordon will skip it even if there's configuration.
 
     The strings must match the plugin's config key. See the plugin's documentation for config key names.
+
+.. option:: debug=true|false
+
+    Whether or not to run the Gordon service in ``debug`` mode.
+
+    If ``true``, Gordon will continue running even if installed & configured plugins can not be loaded. Plugin exceptions will be logged as warnings with tracebacks.
+
+    If ``false``, Gordon will exit out if it can't load one or more plugins.
 
 
 core.logging

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -10,18 +10,15 @@ Example Configuration
 
 An example of a ``gordon.toml`` file:
 
-.. code-block:: ini
-
-    [logging]
-    level = "info"
-    handlers = ["syslog"]
+.. literalinclude:: ../gordon.toml.example
+    :language: ini
 
 
 You may choose to have a ``gordon-user.toml`` file for development. Any top-level key will override what's found in ``gordon.toml``.
 
 .. code-block:: ini
 
-    [logging]
+    [core.logging]
     level = "debug"
     handlers = ["stream"]
 
@@ -31,8 +28,18 @@ Supported Configuration
 
 The following sections are supported:
 
-logging
-~~~~~~~
+core
+~~~~
+
+.. option:: plugins=LIST-OF-STRINGS
+
+    Plugins that the Gordon service needs to load. If a plugin is not listed, Gordon will skip it even if there's configuration.
+
+    The strings must match the plugin's config key. See the plugin's documentation for config key names.
+
+
+core.logging
+~~~~~~~~~~~~
 
 .. option:: level=info(default)|debug|warning|error|critical
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ User's Guide
    :maxdepth: 1
 
    config
+   plugins
    api
 
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,0 +1,11 @@
+Gordon's Plugin System
+======================
+
+.. automodule:: gordon.plugins_loader
+
+
+Writing a Plugin
+----------------
+.. todo::
+
+    Add documentation once interfaces are firmed up

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -1,6 +1,7 @@
 # Gordon Core Config
 [core]
 plugins = ["foo.plugin"]
+debug = false
 
 [core.logging]
 level = "info"

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -1,6 +1,16 @@
 # Gordon Core Config
-[logging]
-level = "debug"
+[core]
+plugins = ["foo.plugin"]
+
+[core.logging]
+level = "info"
 handlers = ["syslog"]
 
-# Extension Config
+# Plugin Config
+["foo"]
+# global config to the general "foo" package
+bar = baz
+
+["foo.plugin"]
+# specific plugin config within "foo" package
+baz = bla

--- a/gordon/exceptions.py
+++ b/gordon/exceptions.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class GordonError(Exception):
+    """General Gordon Application Error."""
+
+
+class LoadPluginsError(GordonError):
+    """Error loading expected plugins."""

--- a/gordon/exceptions.py
+++ b/gordon/exceptions.py
@@ -18,5 +18,5 @@ class GordonError(Exception):
     """General Gordon Application Error."""
 
 
-class LoadPluginsError(GordonError):
-    """Error loading expected plugins."""
+class LoadPluginError(GordonError):
+    """Error loading plugin."""

--- a/gordon/main.py
+++ b/gordon/main.py
@@ -88,7 +88,7 @@ def setup(config_root=''):
               help='Directory where to find service configuration.')
 def run(config_root):
     config = setup(os.path.abspath(config_root))  # NOQA
-    logging.info('Starting gordon v{}...'.format(version))
+    logging.info(f'Starting gordon v{version}...')
 
 
 if __name__ == '__main__':

--- a/gordon/main.py
+++ b/gordon/main.py
@@ -40,6 +40,7 @@ import toml
 import ulogger
 
 from gordon import __version__ as version
+from gordon import plugins_loader
 
 
 def _load_config(root=''):
@@ -72,7 +73,7 @@ def setup(config_root=''):
     """
     config = _load_config(root=config_root)
 
-    logging_config = config.get('logging', {})
+    logging_config = config.get('core', {}).get('logging', {})
     log_level = logging_config.get('level', 'INFO').upper()
     log_handlers = logging_config.get('handlers') or ['syslog']
 
@@ -88,6 +89,11 @@ def setup(config_root=''):
               help='Directory where to find service configuration.')
 def run(config_root):
     config = setup(os.path.abspath(config_root))  # NOQA
+
+    plugin_names, plugins = plugins_loader.load_plugins(config)
+    if plugin_names:
+        logging.info(f'Loaded {len(plugin_names)} plugins: {plugin_names}')
+
     logging.info(f'Starting gordon v{version}...')
 
 

--- a/gordon/plugins_loader.py
+++ b/gordon/plugins_loader.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module for loading plugins distributed via third-party packages.
+
+Plugin discovery is done via ``entry_points`` defined in a package's
+``setup.py``, registered under ``'gordon.plugins'``. For example:
+
+.. code-block:: python
+
+    # setup.py
+    from setuptools import setup
+
+    setup(
+        name=NAME,
+        # snip
+        entry_points={
+            'gordon.plugins': [
+                'gcp.gpubsub = gordon_gcp.gpubsub:EventClient',
+                'gcp.gce.a = gordon_gcp.gce.a:ReferenceSourceClient',
+                'gcp.gce.b = gordon_gcp.gce.b:ReferenceSourceClient',
+                'gcp.gdns = gordon_gcp.gdns:DNSProviderClient',
+            ],
+        },
+        # snip
+    )
+
+Plugins are initialized with any config defined in ``gordon-user.toml``
+and ``gordon.toml``. See :doc:`config` for more details.
+
+Once a plugin is found, the loader looks up its configuration via the
+same key defined in its entry point, e.g. ``gcp.gpubsub``.
+
+The value of the entry point (e.g. ``gordon_gcp.gpubsub:EventClient``)
+must point to a class. The plugin class is instantiated with its config.
+
+A plugin will not have access to another plugin's configuration. For
+example, the ``gcp.gpusub`` will not have access to the configuration
+for ``gcp.gdns``.
+
+See :doc:`plugins` for details on how to write a plugin for Gordon.
+"""
+
+import logging
+
+import pkg_resources
+
+from gordon import exceptions
+
+
+PLUGIN_NAMESPACE = 'gordon.plugins'
+
+
+def _init_plugins(active_plugins, installed_plugins, plugin_configs):
+    inited_plugins = []
+    inited_plugin_names = []
+    for plugin_name, unloaded_plugin in installed_plugins.items():
+        if plugin_name not in active_plugins:
+            continue
+        plugin_class = unloaded_plugin.load()
+        plugin_config = plugin_configs.get(plugin_name)
+
+        # check against `None` because `plugin_config` could be `{}`,
+        # which should be handled by the plugin's logic (i.e. accept all
+        # defaults, or raise error, or something else)
+        if plugin_config is None:
+            msg = (f'Skipped loading plugin "{plugin_name}" because no '
+                   'configuration was found.')
+            logging.info(msg)
+            continue
+
+        try:
+            plugin_object = plugin_class(plugin_config)
+        except Exception as e:
+            msg = f'Could not load {plugin_name}: {e}'
+            raise exceptions.LoadPluginsError(msg)
+
+        inited_plugins.append(plugin_object)
+        inited_plugin_names.append(plugin_name)
+    return inited_plugin_names, inited_plugins
+
+
+def _merge_config(config, namespace):
+    config_copy = config.copy()
+    keys_to_merge = namespace.split('.')
+
+    # DFS approach in order to prefer child config to parent config
+    merged_plugin_config = {}
+    while keys_to_merge:
+        ns = '.'.join(keys_to_merge)
+        plugin_config = config_copy.get(ns, {})
+        plugin_config_copy = plugin_config.copy()
+        plugin_config_copy.update(merged_plugin_config)
+        merged_plugin_config = plugin_config_copy
+        keys_to_merge.pop()
+    return merged_plugin_config
+
+
+def _get_namespaced_config(config, plugin_namespace, all_plugins):
+    plugin_config_keys = plugin_namespace.split('.')
+
+    # drill down to get config that matches plugin namespace
+    while plugin_config_keys:
+        key = plugin_config_keys.pop(0)
+        config = config.get(key)
+
+    # find which config namespaces map to other plugins
+    plugin_config_keys_to_exclude = set()
+    for plugin in all_plugins:
+        if plugin == plugin_namespace:
+            continue
+        if plugin.startswith(plugin_namespace):
+            # exclude same level & lower config keys for other plugins
+            keys_to_exclude = plugin.lstrip(plugin_namespace).split('.')
+            plugin_config_keys_to_exclude.update(keys_to_exclude)
+
+    # clean up config by removing other plugin configs
+    plugin_config = config.copy()
+    while plugin_config_keys_to_exclude:
+        key = plugin_config_keys_to_exclude.pop()
+        try:
+            plugin_config.pop(key)
+        except KeyError:
+            pass
+
+    return plugin_namespace, plugin_config
+
+
+def _load_plugin_configs(plugin_names, config):
+    # A plugin should only have access to its own config and
+    # parent/global plugin config, but not configs of other plugins
+    plugin_configs = {}
+    for plugin in plugin_names:
+        namespace, plugin_conf = _get_namespaced_config(
+            config, plugin, plugin_names)
+        plugin_configs[namespace] = plugin_conf
+
+    # merge namespaced with parent / global plugin config
+    merged_configs = {}
+    for namespace in plugin_configs.keys():
+        plugin_config = _merge_config(plugin_configs, namespace)
+        merged_configs[namespace] = plugin_config
+
+    return merged_configs
+
+
+def _get_plugin_config_keys(plugins):
+    # Make sure all parent namespaces of a plugin are available
+    # to load config for easy config handling
+    defined_plugin_namespace = plugins.keys()
+    all_config_keys = set()
+    for namespace in defined_plugin_namespace:
+        namespaces = namespace.split('.')
+        namespaces_to_build = []
+        while len(namespaces):
+            namespace = namespaces.pop(0)
+            namespaces_to_build.append(namespace)
+            config_key = '.'.join(namespaces_to_build)
+            all_config_keys.add(config_key)
+    return sorted(list(all_config_keys))
+
+
+def _get_activated_plugins(config, installed_plugins):
+    activated_plugins = config.get('core', {}).get('plugins', [])
+    for active_plugin in activated_plugins:
+        if active_plugin not in installed_plugins:
+            msg = f'Plugin "{active_plugin}" not installed'
+            raise exceptions.LoadPluginsError(msg)
+    return activated_plugins
+
+
+def _gather_installed_plugins():
+    gathered_plugins = {}
+    for entry_point in pkg_resources.iter_entry_points(PLUGIN_NAMESPACE):
+        gathered_plugins[entry_point.name] = entry_point
+    return gathered_plugins
+
+
+def load_plugins(config):
+    """
+    Discover and instantiate plugins.
+
+    Args:
+        config (dict): loaded configuration for the Gordon service.
+    Returns:
+        Tuple of 2 lists: list of names of plugins, then list of
+        instantiated plugin objects. A tuple of two empty lists is
+        return if there are no plugins found or activated in gordon
+        config.
+    """
+    installed_plugins = _gather_installed_plugins()
+    active_plugins = _get_activated_plugins(config, installed_plugins)
+    if not active_plugins:
+        return [], []
+    plugin_namespaces = _get_plugin_config_keys(installed_plugins)
+    plugin_configs = _load_plugin_configs(plugin_namespaces, config)
+    return _init_plugins(active_plugins, installed_plugins, plugin_configs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==6.7
+setuptools==38.2.5
 toml==0.9.3.1
 ulogger==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ NAME = 'gordon-dns'
 PACKAGE_NAME = 'gordon'
 PACKAGES = find_packages(where='.')
 META_PATH = os.path.join(PACKAGE_NAME, '__init__.py')
-KEYWORDS = ['dns', 'gcp']
+KEYWORDS = ['dns']
 CLASSIFIERS = [
     'Development Status :: 1 - Planning',
     'License :: OSI Approved :: Apache Software License',
@@ -94,6 +94,12 @@ setup(
     maintainer=find_meta('author'),
     maintainer_email=find_meta('email'),
     packages=PACKAGES,
+    entry_points={
+        'console_scripts': [
+            'gordon = gordon.main:run'
+        ],
+        'gordon.plugins': []
+    },
     classifiers=CLASSIFIERS,
     keywords=KEYWORDS,
     zip_safe=False,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ flake8-import-order==0.16
 pytest==3.2.5
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
+pytest-mock==1.6.3

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,10 +26,19 @@ class FakePlugin:
         self.config = config
 
 
+@pytest.fixture
+def plugin_exc_mock():
+    class FakePluginException(Exception):
+        """Exception raised from a plugin when loading"""
+        pass
+    return FakePluginException('dangit')
+
+
 @pytest.fixture(scope='session')
 def config_file():
     return ('[core]\n'
             'plugins = ["one.plugin", "two.plugin"]\n'
+            'debug = true\n'
             '[core.logging]\n'
             'level = "debug"\n'
             'handlers = ["stream"]\n'
@@ -47,6 +56,7 @@ def loaded_config():
     return {
         'core': {
             'plugins': ['one.plugin', 'two.plugin'],
+            'debug': True,
             'logging': {
                 'level': 'debug',
                 'handlers': ['stream'],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,11 +17,63 @@
 Module for reusable pytest fixtures.
 """
 
+import pkg_resources
 import pytest
+
+
+class FakePlugin:
+    def __init__(self, config):
+        self.config = config
 
 
 @pytest.fixture(scope='session')
 def config_file():
-    return ('[logging]\n'
+    return ('[core]\n'
+            'plugins = ["one.plugin", "two.plugin"]\n'
+            '[core.logging]\n'
             'level = "debug"\n'
-            'handlers = ["stream"]')
+            'handlers = ["stream"]\n'
+            '[one]\n'
+            'a_key = "a_value"\n'
+            'b_key = "b_value"\n'
+            '[one.plugin]\n'
+            'a_key = "another_value"\n'
+            '[two.plugin]\n'
+            'd_key = "d_value"')
+
+
+@pytest.fixture
+def loaded_config():
+    return {
+        'core': {
+            'plugins': ['one.plugin', 'two.plugin'],
+            'logging': {
+                'level': 'debug',
+                'handlers': ['stream'],
+            }
+        },
+        'one': {
+            'a_key': 'a_value',
+            'b_key': 'b_value',
+            'plugin': {
+                'a_key': 'another_value',
+            },
+        },
+        'two': {
+            'plugin': {
+                'd_key': 'd_value',
+            },
+        },
+    }
+
+
+@pytest.fixture
+def plugins(mocker):
+    plugins = {}
+    names = ['one.plugin', 'two.plugin']
+    for name in names:
+        plugin_mock = mocker.MagicMock(pkg_resources.EntryPoint, autospec=True)
+        plugin_mock.name = name
+        plugin_mock.load.return_value = FakePlugin
+        plugins[name] = plugin_mock
+    return plugins

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,12 +17,11 @@
 Module for reusable pytest fixtures.
 """
 
-
 import pytest
 
 
 @pytest.fixture(scope='session')
-def config_fixture():
+def config_file():
     return ('[logging]\n'
             'level = "debug"\n'
             'handlers = ["stream"]')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -26,12 +26,12 @@ from gordon import main
 # Tests for service setup
 #####
 @pytest.mark.parametrize('suffix', ['', '-user'])
-def test_load_config(tmpdir, suffix, config_fixture):
+def test_load_config(tmpdir, suffix, config_file):
     """
     Load prod and user config.
     """
     conf_file = tmpdir.mkdir('config').join('gordon{}.toml'.format(suffix))
-    conf_file.write(config_fixture)
+    conf_file.write(config_file)
     config = main._load_config(root=conf_file.dirpath())
 
     expected = {'logging': {'level': 'debug', 'handlers': ['stream']}}
@@ -49,12 +49,12 @@ def test_load_config_raises(tmpdir):
     assert e.match('Cannot load Gordon configuration file from')
 
 
-def test_setup(tmpdir, monkeypatch, config_fixture):
+def test_setup(tmpdir, monkeypatch, config_file):
     """
     Setup service config and logging.
     """
     conf_file = tmpdir.mkdir('config').join('gordon.toml')
-    conf_file.write(config_fixture)
+    conf_file.write(config_file)
 
     ulogger_mock = mock.MagicMock(main.ulogger, autospec=True)
     ulogger_mock.setup_logging = mock.Mock()

--- a/tests/unit/test_plugins_loader.py
+++ b/tests/unit/test_plugins_loader.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pkg_resources
+import pytest
+
+from gordon import exceptions
+from gordon import plugins_loader
+from tests.unit.conftest import FakePlugin
+
+
+#####
+# Fixtures
+#####
+@pytest.fixture(scope='session')
+def namespaced_config():
+    return {
+        'one': {'a_key': 'a_value', 'b_key': 'b_value'},
+        'one.plugin': {'a_key': 'another_value'},
+        'two': {},
+        'two.plugin': {'d_key': 'd_value'}
+    }
+
+
+@pytest.fixture(scope='session')
+def plugin_config():
+    return {
+        'one.plugin': {
+            'a_key': 'another_value',
+            'b_key': 'b_value'
+        },
+        'two.plugin': {
+            'd_key': 'd_value'
+        },
+    }
+
+
+@pytest.fixture(scope='session')
+def exp_inited_plugins(plugin_config):
+    return [
+        FakePlugin(plugin_config.get('one.plugin')),
+        FakePlugin(plugin_config.get('two.plugin'))
+    ]
+
+
+@pytest.fixture
+def mock_iter_entry_points(mocker, monkeypatch, plugins):
+    mock_plugins = plugins.values()
+
+    mock_iter_entry_points = mocker.MagicMock(pkg_resources.iter_entry_points)
+    mock_iter_entry_points.return_value = iter(mock_plugins)
+    monkeypatch.setattr(
+        plugins_loader.pkg_resources, 'iter_entry_points',
+        mock_iter_entry_points)
+
+
+#####
+# The good stuff
+#####
+def test_init_plugins(plugins, plugin_config, exp_inited_plugins):
+    """Plugins are initialized with their config."""
+    active_plugins = ['one.plugin', 'two.plugin']
+    inited_names, inited_plugins = plugins_loader._init_plugins(
+        active_plugins, plugins, plugin_config)
+
+    assert active_plugins == sorted(inited_names)
+    for plugin_obj in inited_plugins:
+        assert isinstance(plugin_obj, FakePlugin)
+        assert any([p.config == plugin_obj.config for p in exp_inited_plugins])
+
+
+def test_init_plugins_raises(mocker):
+    """Non-callable plugin raises LoadPluginError."""
+    name = 'B0rkedPlugin'
+    config = {'B0rkedPlugin': {'foo': 'bar'}}
+
+    plugin_mock = mocker.MagicMock(pkg_resources.EntryPoint, autospec=True)
+    plugin_mock.name = name
+    plugin_mock.load.return_value = 'not_a_class'
+    plugins = {name: plugin_mock}
+
+    with pytest.raises(exceptions.LoadPluginsError) as e:
+        plugins_loader._init_plugins([name], plugins, config)
+
+    e.match('Could not load B0rkedPlugin: ')
+
+
+def test_init_plugins_skipped(plugins, plugin_config, caplog):
+    """Skips plugins that are not configured."""
+    active_plugins = ['one.plugin', 'two.plugin']
+    config = {'one.plugin': plugin_config['one.plugin']}
+
+    inited_names, inited_plugins = plugins_loader._init_plugins(
+        active_plugins, plugins, config)
+
+    assert 1 == len(inited_plugins) == len(inited_names)
+    assert 1 == len(caplog.records)
+
+
+def test_init_plugins_empty_config(plugins):
+    """Loads plugin if mathcing config key exists with empty config."""
+    active_plugins = ['one.plugin', 'two.plugin']
+    config = {
+        'one.plugin': {},
+        'two.plugin': {}
+    }
+
+    inited_names, inited_plugins = plugins_loader._init_plugins(
+        active_plugins, plugins, config)
+
+    assert 2 == len(inited_plugins) == len(inited_names)
+    for plugin_obj in inited_plugins:
+        # assert isinstance(plugin_obj, FakePlugin)
+        assert {} == plugin_obj.config
+
+
+def test_init_plugins_skip_inactive(plugins, plugin_config):
+    """Skips plugins that are not activated in core config."""
+    active_plugins = ['one.plugin']
+    inited_names, inited_plugins = plugins_loader._init_plugins(
+        active_plugins, plugins, plugin_config)
+
+    assert 1 == len(inited_plugins) == len(inited_names)
+    assert plugin_config.get('one.plugin') == inited_plugins[0].config
+
+
+merge_args = 'namespace,exp_config'
+merge_params = [
+    ('one', {'a_key': 'a_value', 'b_key': 'b_value'}),
+    ('one.plugin', {'a_key': 'another_value', 'b_key': 'b_value'}),
+    ('two', {}),
+    ('two.plugin', {'d_key': 'd_value'}),
+]
+
+
+@pytest.mark.parametrize(merge_args, merge_params)
+def test_merge_config(namespace, exp_config, namespaced_config):
+    """Namespaced config for a plugin also has parent/global config."""
+    ret_config = plugins_loader._merge_config(namespaced_config, namespace)
+
+    assert exp_config == ret_config
+
+
+namespace_args = 'namespace,exp_config'
+namespace_params = [
+    ('one', {'a_key': 'a_value', 'b_key': 'b_value'}),
+    ('one.plugin', {'a_key': 'another_value'}),
+    ('two', {}),
+    ('two.plugin', {'d_key': 'd_value'}),
+]
+
+
+@pytest.mark.parametrize(namespace_args, namespace_params)
+def test_get_namespaced_config(namespace, exp_config, plugins, loaded_config):
+    """Tease out config specific to a plugin with no parent config."""
+    all_plugins = plugins.keys()
+    ret_namespace, ret_config = plugins_loader._get_namespaced_config(
+        loaded_config, namespace, all_plugins)
+
+    assert exp_config == ret_config
+    assert namespace == ret_namespace
+
+
+def test_load_plugin_configs(plugins, loaded_config, plugin_config):
+    """Load plugin-specific config ignoring other plugins' configs."""
+    plugin_names = ['one', 'one.plugin', 'two', 'two.plugin']
+    parsed_config = plugins_loader._load_plugin_configs(
+        plugin_names, loaded_config)
+    assert plugin_config['one.plugin'] == parsed_config['one.plugin']
+    assert plugin_config['two.plugin'] == parsed_config['two.plugin']
+
+
+def test_get_plugin_config_keys(plugins):
+    """Entry point keys for plugins are parsed to config keys."""
+    config_keys = plugins_loader._get_plugin_config_keys(plugins)
+    expected = ['one', 'one.plugin', 'two', 'two.plugin']
+    assert expected == config_keys
+
+
+def test_get_activated_plugins(loaded_config, plugins):
+    """Assert activated plugins are installed."""
+    active = plugins_loader._get_activated_plugins(loaded_config, plugins)
+
+    assert ['one.plugin', 'two.plugin'] == active
+
+
+def test_get_activated_plugins_raises(loaded_config, plugins):
+    """Raise when activated plugins are not installed."""
+    loaded_config['core']['plugins'].append('three.plugin')
+
+    with pytest.raises(exceptions.LoadPluginsError) as e:
+        plugins_loader._get_activated_plugins(loaded_config, plugins)
+
+    e.match('Plugin "three.plugin" not installed')
+
+
+def test_gather_installed_plugins(mock_iter_entry_points, plugins):
+    """Gather entry points/plugins into a {name: entry point} format."""
+    gathered_plugins = plugins_loader._gather_installed_plugins()
+    assert plugins == gathered_plugins
+
+
+def test_load_plugins(mock_iter_entry_points, loaded_config, plugins,
+                      exp_inited_plugins):
+    """Plugins are loaded and instantiated with their config."""
+    inited_names, loaded_plugins = plugins_loader.load_plugins(loaded_config)
+
+    assert 2 == len(inited_names) == len(loaded_plugins)
+    for plugin_obj in loaded_plugins:
+        assert isinstance(plugin_obj, FakePlugin)
+        assert any([p.config == plugin_obj.config for p in exp_inited_plugins])
+
+
+def test_load_plugins_none_loaded(mocker, plugins, exp_inited_plugins):
+    """Return empty list when no plugins are found."""
+    mock_iter_entry_points = mocker.MagicMock(pkg_resources.iter_entry_points)
+    mock_iter_entry_points.return_value = []
+
+    loaded_config = {'core': {}}
+    inited_names, loaded_plugins = plugins_loader.load_plugins(loaded_config)
+    assert [] == loaded_plugins == inited_names

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,9 @@ commands = check-manifest
 [flake8]
 show-source = true
 max-line-length = 80
-exclude = .venv,.tox,.git,dist,doc,*.egg,build
+exclude = .venv,.tox,.git,dist,doc,*.egg,build,scratch.py
 import-order-style = edited
-application-import-names = gordon
+application-import-names = gordon,tests
 
 [pytest]
 addopts = -v --cov=gordon --cov-report=html --cov-report=xml --cov-report=term-missing


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <TODO: LINK TO CONTRIBUTING.MD>  // is this necessary since github refers to it when opening a pull request?
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
3. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

When setting this up, I essentially followed [these docs](https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata); [this resource](http://amir.rachum.com/blog/2017/07/28/python-entry-points/) also helped a lot.

Once we define the interfaces for things like DNS, pubsub, and source-of-truth providers, I'll firm up the docs on how to setup a 3rd-party plugin. But basically, the way this works is it looks at all the packages within the python path (i.e. a virtualenv), and looks for `'gordon.plugins'` key as an entry point defined within `setup.py`. An example of a 3rd party package's `setup.py`:

```python
# snip
setup(
    name=NAME,
    version=find_meta('version'),
    # snip
    entry_points={
        'gordon.plugins': [
            'gcp.gpubsub = gordon_gcp.gpubsub:ImplementPubSubInterface',
            'gcp.gce = gordon_gcp.gce:ImplementedSourceOfTruthInterface',
            'gcp.gdns = gordon_gcp.gdns:ImplementedDNSProviderInterface',
        ],
    },
    # snip
)
```

Within the list of `gordon.plugins` is a string that's a key/value pair. The key is the plugin name, which needs to match the namespace within the gordon service's config, e.g.:

```toml
[core]
# snip

[gcp]
project = 'my-project'

[gcp.gce]
keyfile = '/path/to/keyfile.json'
# project will be inherited from [gcp]

[gcp.gdns]
# this overwrites `gcp.project`
project = 'a-different-project' 
# this does not have access to `gcp.gce.keyfile`
```

The value, e.g. `gordon_gcp.gpubsub:ImplementedPubSubInterface`, is a path, needs to point to a callable; for now, this patch assumes the callable is a class. It instantiates the plugin class with its respective config.

Names of interfaces not yet defined. Totally not calling it `ImplementedFooWhateverInterface`.

This is ready for initial review/input; I am going to write an integration test with a sample package.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @spotify/alf 