### PR TITLE
add async worker to collect hostname resolution metrics

### DIFF
--- a/gordon/exceptions.py
+++ b/gordon/exceptions.py
@@ -20,3 +20,7 @@ class GordonError(Exception):
 
 class LoadPluginError(GordonError):
     """Error loading plugin."""
+
+
+class InvalidDNSHost(GordonError):
+    """Error when given invalid DNS server to query"""

--- a/gordon/record_checker.py
+++ b/gordon/record_checker.py
@@ -19,7 +19,6 @@ import logging
 import time
 
 import async_dns
-
 from async_dns.resolver import ProxyResolver
 
 from gordon import exceptions

--- a/gordon/record_checker.py
+++ b/gordon/record_checker.py
@@ -91,7 +91,8 @@ class RecordChecker(object):
                 f'Sending metric record-checker-failed: {record}')
         else:
             final_time = float(time.time() - start_time)
-            logging.info(final_time)
+            success_msg = f'This record: {record} took {final_time} to register'
+            logging.info(success_msg)
 
     async def _check_resolver_ans(
             self, dns_answer_list, record_name,
@@ -120,8 +121,8 @@ class RecordChecker(object):
         # check each record data is equal to the given data
         for rec in type_filtered_list:
             conditions = [rec.name == record_name,
-                          rec.data in record_ip_list,
-                          rec.ttl == record_ttl]
+                          rec.ttl == record_ttl,
+                          rec.data in record_ip_list]
 
             # if ans record data is not equal
             # to the given data return False

--- a/gordon/record_checker.py
+++ b/gordon/record_checker.py
@@ -1,0 +1,112 @@
+import asyncio
+import logging
+import time
+
+from async_dns import types
+from async_dns.resolver import ProxyResolver
+
+
+class RecordChecker(object):
+    QUERYING_THRESHOLD = 60
+
+    def __init__(self, dns_ip):
+        """Setup RecordChecker object
+
+        Args:
+            dns_ip: DNS ip server to query
+        """
+        self._dns_ip = dns_ip
+        self._resolver = ProxyResolver()
+        self._resolver.set_proxies([self._dns_ip])
+
+    def _extract_record_data(self, record):
+        """Extract record data from a record dict
+
+        Args:
+            record (dict): DNS record as a dict
+        """
+        return record.values()
+
+    async def check_record(self, record):
+        """Asynchronously queries a DNS server for a given record
+            to check how long it takes the record to become available.
+
+        Args:
+            record (dict): DNS record as a dict
+            with record properties
+
+        """
+        start_time = time.time()
+
+        name, rr_data, r_type, ttl = self._extract_record_data(record)
+        r_type_code = types.get_code(r_type)
+
+        record_found_in_dns_srv = False
+        query_tries = 0
+
+        while not record_found_in_dns_srv and\
+                self.QUERYING_THRESHOLD != query_tries:
+
+            query_tries += 1
+            resolver_res = await self._resolver.query(name, r_type_code)
+            possible_ans = resolver_res.an
+
+            record_found_in_dns_srv = \
+                await self._check_resolver_ans(possible_ans, name,
+                                               rr_data, ttl, r_type_code)
+            await asyncio.sleep(1)
+
+        if not record_found_in_dns_srv:
+            logging.info(
+                f'Sending metric record-checker-failed: {record}')
+        else:
+            final_time = float(time.time() - start_time)
+            logging.info(final_time)
+
+    async def _check_resolver_ans(
+            self, dns_ans_lst, name, rr_data, ttl, r_type_code):
+        """Check if resolver ans is equal to record data.
+
+        Args:
+            dns_ans_lst (list): DNS answer list contains record objects
+            name (str): record name
+            rr_data (list): list of ips for the record
+            ttl (int): record time ot live info
+            r_type_code (int): record type code
+
+        Returns:
+            boolean indicating if DNS ans data is equal to record data
+        """
+        type_filtered_lst = \
+            list(filter(lambda r: r.qtype == r_type_code, dns_ans_lst))
+
+        # check to see that type_filtered_lst has
+        # the same number of records as record rr_data
+        if len(type_filtered_lst) != len(rr_data):
+            return False
+
+        # check each record data is equal to the given data
+        for rec in type_filtered_lst:
+            conditions = [name == rec.name,
+                          rec.data in rr_data,
+                          rec.ttl == ttl]
+
+            # if ans record data is not equal
+            # to the given data return False
+            if not all(conditions):
+                return False
+
+        return True
+
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+
+    record_check = RecordChecker('8.8.8.8')
+    my_rec = {
+        "name": "ns1.dnsowl.com",
+        "rrdatas": ["198.251.84.16", "173.254.242.221", "185.34.216.159"],
+        "type": "A",
+        "ttl": 4945
+    }
+    loop.run_until_complete(record_check.check_record(my_rec))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ setuptools==38.2.5
 toml==0.9.3.1
 ulogger==1.0.1
 zope.interface==4.4.3
+async-dns=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ setuptools==38.2.5
 toml==0.9.3.1
 ulogger==1.0.1
 zope.interface==4.4.3
-async-dns=1.0.0
+async-dns==1.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ pytest==3.2.5
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-mock==1.6.3
+pytest-asyncio==0.8.0

--- a/tests/unit/test_record_check.py
+++ b/tests/unit/test_record_check.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from async_dns import Record
+
+from gordon import record_checker
+
+
+#####
+# Tests & fixtures for running record checker
+#####
+
+@pytest.fixture
+def record_checker_instance():
+    dnc_ip = '8.8.8.8'
+    return record_checker.RecordChecker(dnc_ip)
+
+
+@pytest.fixture
+def record_1(mocker):
+    record_mock = mocker.Mock(Record)
+    record_mock.qtype = 1
+    record_mock.name = 'ns1.dnsowl.com'
+    record_mock.data = '185.34.216.159'
+    record_mock.ttl = 10686
+    return record_mock
+
+
+@pytest.fixture
+def record_2(record_1):
+    record_1.data = '173.254.242.221'
+    return record_1
+
+
+@pytest.fixture
+def record_3(record_1):
+    record_1.data = '198.251.84.16'
+    return record_1
+
+
+@pytest.fixture
+def dns_query_response(mocker, record_1, record_2, record_3):
+    dns_res_mock = mocker.Mock()
+    dns_res_mock.an = [record_1, record_2, record_3]
+    return dns_res_mock
+
+
+@pytest.fixture
+def get_mock_coro(mocker):
+    """Create a mock-coro pair.
+    The coro can be used to patch an async method while the mock can
+    be used to assert calls to the mocked out method.
+    """
+    def _create_mock_coro_pair():
+        mock = mocker.Mock()
+
+        async def _coro(*args, **kwargs):
+            return mock(*args, **kwargs)
+        return mock, _coro
+    return _create_mock_coro_pair
+
+
+@pytest.fixture
+def mock_resolve_query(mocker, get_mock_coro, record_checker_instance):
+    mock, _coroutine = get_mock_coro()
+    mocker.patch.object(record_checker_instance._resolver, "query", _coroutine)
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_check_record_time_range_check(
+        record_checker_instance, caplog,
+        mock_resolve_query, dns_query_response):
+    """Test the time it took to check a record is in expected range"""
+    record_to_check = {
+        "name": "ns1.dnsowl.com",
+        "rrdatas": ["198.251.84.16", "173.254.242.221", "185.34.216.159"],
+        "type": "A",
+        "ttl": 10686
+    }
+
+    mock_resolve_query.return_value = dns_query_response
+
+    await record_checker_instance.check_record(record_to_check)
+    time_it_took_to_check_record = float(caplog.records[0].msg)
+    assert 0 < time_it_took_to_check_record < 1.005
+
+
+@pytest.mark.asyncio
+async def test_check_record_failed(
+        mocker, get_mock_coro,
+        record_checker_instance, caplog,
+        mock_resolve_query, dns_query_response):
+    """Test we get a failure logging msg for the case of failure:
+        we didn't get available record from the DNS"""
+    record_to_check = {
+        "name": "ns1.dnsowl.com",
+        "rrdatas": ["198.251.84.15", "173.254.242.221", "185.34.216.159"],
+        "type": "A",
+        "ttl": 10686
+    }
+
+    mock_resolve_query.return_value = dns_query_response
+
+    mock, _coroutine = get_mock_coro()
+    mocker.patch('asyncio.sleep', _coroutine)
+
+    await record_checker_instance.check_record(record_to_check)
+    failed_msg = caplog.records[0].msg
+
+    expected_msg = f'Sending metric record-checker-failed: {record_to_check}'
+    assert failed_msg == expected_msg
+
+
+@pytest.mark.asyncio
+async def test_check_number_of_rrdata_is_not_equal(
+        mocker, get_mock_coro,
+        record_checker_instance, caplog,
+        mock_resolve_query, dns_query_response):
+    """Test that we fail on getting number of records
+        from the srv which is not eqaule to the
+        len of rrdata of our record """
+    record_to_check = {
+        "name": "ns1.dnsowl.com",
+        "rrdatas": ["198.251.84.16", "173.254.242.221"],
+        "type": "A",
+        "ttl": 10686
+    }
+
+    mock_resolve_query.return_value = dns_query_response
+
+    mock, _coroutine = get_mock_coro()
+    mocker.patch('asyncio.sleep', _coroutine)
+
+    await record_checker_instance.check_record(record_to_check)
+    failed_msg = caplog.records[0].msg
+
+    expected_msg = f'Sending metric record-checker-failed: {record_to_check}'
+    assert expected_msg == failed_msg

--- a/tests/unit/test_record_checker.py
+++ b/tests/unit/test_record_checker.py
@@ -34,21 +34,21 @@ def record_checker_instance():
 def record_1(mocker):
     record_mock = mocker.Mock(Record)
     record_mock.qtype = 1
-    record_mock.name = 'ns1.dnsowl.com'
-    record_mock.data = '185.34.216.159'
+    record_mock.name = 'example.com'
+    record_mock.data = '127.1.1.1'
     record_mock.ttl = 10686
     return record_mock
 
 
 @pytest.fixture
 def record_2(record_1):
-    record_1.data = '173.254.242.221'
+    record_1.data = '127.1.1.2'
     return record_1
 
 
 @pytest.fixture
 def record_3(record_1):
-    record_1.data = '198.251.84.16'
+    record_1.data = '127.1.1.3'
     return record_1
 
 
@@ -77,7 +77,7 @@ def get_mock_coro(mocker):
 @pytest.fixture
 def mock_resolve_query(mocker, get_mock_coro, record_checker_instance):
     mock, _coroutine = get_mock_coro()
-    mocker.patch.object(record_checker_instance._resolver, "query", _coroutine)
+    mocker.patch.object(record_checker_instance._resolver, 'query', _coroutine)
     return mock
 
 
@@ -87,17 +87,17 @@ async def test_check_record_time_range_check(
         mock_resolve_query, dns_query_response):
     """Test the time it took to check a record is in expected range"""
     record_to_check = {
-        "name": "ns1.dnsowl.com",
-        "rrdatas": ["198.251.84.16", "173.254.242.221", "185.34.216.159"],
-        "type": "A",
-        "ttl": 10686
+        'name': 'example.com',
+        'rrdatas': ['127.1.1.1', '127.1.1.2', '127.1.1.3'],
+        'type': 'A',
+        'ttl': 10686
     }
 
     mock_resolve_query.return_value = dns_query_response
 
     await record_checker_instance.check_record(record_to_check)
     time_it_took_to_check_record = float(caplog.records[0].msg)
-    assert 0 < time_it_took_to_check_record < 1.005
+    assert 0 < time_it_took_to_check_record < 3
 
 
 @pytest.mark.asyncio
@@ -108,10 +108,10 @@ async def test_check_record_failed(
     """Test we get a failure logging msg for the case of failure:
         we didn't get available record from the DNS"""
     record_to_check = {
-        "name": "ns1.dnsowl.com",
-        "rrdatas": ["198.251.84.15", "173.254.242.221", "185.34.216.159"],
-        "type": "A",
-        "ttl": 10686
+        'name': 'example.com',
+        'rrdatas': ['127.1.1.1', '127.1.1.2', '127.1.1.3'],
+        'type': 'A',
+        'ttl': 1068
     }
 
     mock_resolve_query.return_value = dns_query_response
@@ -132,13 +132,13 @@ async def test_check_number_of_rrdata_is_not_equal(
         record_checker_instance, caplog,
         mock_resolve_query, dns_query_response):
     """Test that we fail on getting number of records
-        from the srv which is not eqaule to the
+        from the server which is not equal to the
         len of rrdata of our record """
     record_to_check = {
-        "name": "ns1.dnsowl.com",
-        "rrdatas": ["198.251.84.16", "173.254.242.221"],
-        "type": "A",
-        "ttl": 10686
+        'name': 'example.com',
+        'rrdatas': ['127.1.1.1', '127.1.1.2'],
+        'type': 'A',
+        'ttl': 10686
     }
 
     mock_resolve_query.return_value = dns_query_response

--- a/tests/unit/test_record_checker.py
+++ b/tests/unit/test_record_checker.py
@@ -17,7 +17,7 @@
 import pytest
 from async_dns import Record
 
-from gordon import record_checker, exceptions
+from gordon import exceptions, record_checker
 
 
 #####

--- a/tests/unit/test_record_checker.py
+++ b/tests/unit/test_record_checker.py
@@ -97,9 +97,13 @@ async def test_check_time_on_success(
 
     await record_checker_instance.check_record(record_to_check)
 
-    time_it_took_to_check_record = float(caplog.records[0].msg)
+    success_msg = caplog.records[0].msg
+
+    time_it_took_to_check_record = \
+        float(success_msg.split('took ')[1].split(' to')[0])
 
     max_time_to_sleep_when_success = 6
+
     assert 0 < time_it_took_to_check_record < max_time_to_sleep_when_success
 
 
@@ -125,10 +129,10 @@ async def test_check_record_failure_ttl_not_equal(
     mocker.patch('asyncio.sleep', _coroutine)
 
     await record_checker_instance.check_record(record_to_check)
-    failed_msg = caplog.records[0].msg
+    actual_msg = caplog.records[0].msg
 
     expected_msg = f'Sending metric record-checker-failed: {record_to_check}'
-    assert failed_msg == expected_msg
+    assert expected_msg == actual_msg
 
 
 @pytest.mark.asyncio
@@ -154,10 +158,10 @@ async def test_length_of_rrdata_is_not_equal(
     mocker.patch('asyncio.sleep', _coroutine)
 
     await record_checker_instance.check_record(record_to_check)
-    failed_msg = caplog.records[0].msg
+    actual_msg = caplog.records[0].msg
 
     expected_msg = f'Sending metric record-checker-failed: {record_to_check}'
-    assert expected_msg == failed_msg
+    assert expected_msg == actual_msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

The ticket intention was to add async worker to collect hostname resolution metrics, but for start I only log the time it takes to check if there is an available record in a given DNS server.
If there isn't an available record we logging a failure msg.

**Which issue(s) this PR fixes** 
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
NONE

```release-note

```

@matt0bi @spotify/alf @steven @skinner