### PR TITLE
Update interface definitions + Add logic to start plugins

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.txt LICENSE tox.ini .coveragerc *.rst *.toml.example OWNERS
 recursive-include gordon *.py
-recursive-include tests *.py
+recursive-include tests *.py *.toml
 
 # Exclude service-specific config
 exclude gordon*.toml

--- a/gordon/exceptions.py
+++ b/gordon/exceptions.py
@@ -24,3 +24,11 @@ class LoadPluginError(GordonError):
 
 class InvalidDNSHost(GordonError):
     """Error when given invalid DNS server to query."""
+
+
+class MissingPluginError(GordonError):
+    """Missing a required plugin."""
+
+
+class InvalidPluginError(GordonError):
+    """Plugin implementation is invalid."""

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -35,11 +35,20 @@ class IEventMessage(Interface):
             phase (str): Current phase.
         """
 
-    def append_to_history(entry):
+    def append_to_history(entry, plugin_phase):
         """Append entry to the IEventMessage's history_log.
 
         Args:
             entry (str): Information to append to log.
+            plugin_phase (str): Phase of plugin that created the log
+                entry message.
+        """
+
+    def update_phase(new_phase):
+        """Update the phase of a message to new phase.
+
+        Args:
+            new_phase (str): Phase to update the message to.
         """
 
 
@@ -52,7 +61,7 @@ class IGenericPlugin(Interface):
     """
     phase = Attribute('Plugin phase')
 
-    def __init__(config, success_channel, error_channel, loop, metrics=None):
+    def __init__(config, success_channel, error_channel, metrics=None):
         """Initialize an EventClient object.
 
         Args:
@@ -61,16 +70,11 @@ class IGenericPlugin(Interface):
                 IEventMessages.
             error_channel (asyncio.Queue): A sink for IEventMessages that were
                 not processed due to problems.
-            loop (obj): Object implementing asyncio.AbstractEventLoop.
             metrics (obj): Optional obj used to emit metrics.
         """
 
-    async def update_phase(event_msg):
-        """Update the phase of a message to current phase.
-
-        Args:
-            event_msg (IEventMessage): Message with stale phase.
-        """
+    async def shutdown():
+        """Gracefully shutdown plugin."""
 
 
 class IEventConsumerClient(IGenericPlugin):
@@ -81,7 +85,7 @@ class IEventConsumerClient(IGenericPlugin):
     to perform cleanup if needed.
     """
 
-    async def start():
+    async def run():
         """Begin consuming messages using the provided event loop."""
 
     async def cleanup(event_msg):

--- a/gordon/plugins_loader.py
+++ b/gordon/plugins_loader.py
@@ -195,9 +195,10 @@ def load_plugins(config, plugin_kwargs):
         plugin_kwargs (dict): keyword arguments to give to plugins
             during instantiation.
     Returns:
-        Tuple of 2 lists: list of names of plugins, then list of
-        instantiated plugin objects. A tuple of two empty lists is
-        return if there are no plugins found or activated in gordon
+        Tuple of 3 lists: list of names of plugins, list of
+        instantiated plugin objects, and any errors encountered while
+        loading/instantiating plugins. A tuple of three empty lists is
+        returned if there are no plugins found or activated in gordon
         config.
     """
     installed_plugins = _gather_installed_plugins()

--- a/gordon/plugins_loader.py
+++ b/gordon/plugins_loader.py
@@ -64,13 +64,13 @@ from gordon import exceptions
 PLUGIN_NAMESPACE = 'gordon.plugins'
 
 
-def _init_plugins(active_plugins, installed_plugins, plugin_configs):
+def _init_plugins(active, installed, configs, kwargs):
     inited_plugins, inited_plugin_names, errors = [], [], []
-    for plugin_name, unloaded_plugin in installed_plugins.items():
-        if plugin_name not in active_plugins:
+    for plugin_name, unloaded_plugin in installed.items():
+        if plugin_name not in active:
             continue
         plugin_class = unloaded_plugin.load()
-        plugin_config = plugin_configs.get(plugin_name)
+        plugin_config = configs.get(plugin_name)
 
         # check against `None` because `plugin_config` could be `{}`,
         # which should be handled by the plugin's logic (i.e. accept all
@@ -82,7 +82,7 @@ def _init_plugins(active_plugins, installed_plugins, plugin_configs):
             continue
 
         try:
-            plugin_object = plugin_class(plugin_config)
+            plugin_object = plugin_class(plugin_config, **kwargs)
             inited_plugins.append(plugin_object)
             inited_plugin_names.append(plugin_name)
         except Exception as e:
@@ -186,12 +186,14 @@ def _gather_installed_plugins():
     return gathered_plugins
 
 
-def load_plugins(config):
+def load_plugins(config, plugin_kwargs):
     """
     Discover and instantiate plugins.
 
     Args:
         config (dict): loaded configuration for the Gordon service.
+        plugin_kwargs (dict): keyword arguments to give to plugins
+            during instantiation.
     Returns:
         Tuple of 2 lists: list of names of plugins, then list of
         instantiated plugin objects. A tuple of two empty lists is
@@ -204,4 +206,5 @@ def load_plugins(config):
         return [], [], []
     plugin_namespaces = _get_plugin_config_keys(active_plugins)
     plugin_configs = _load_plugin_configs(plugin_namespaces, config)
-    return _init_plugins(active_plugins, installed_plugins, plugin_configs)
+    return _init_plugins(
+        active_plugins, installed_plugins, plugin_configs, plugin_kwargs)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,6 +28,13 @@ import zope.interface
 from gordon import interfaces
 
 
+PLUGIN_NAMES = ['event_consumer', 'enricher', 'publisher', 'runnable']
+# what plugins are registered as within `setup.py:setup.entry_points`
+REGISTERED_PLUGINS = ['xyz.' + p for p in PLUGIN_NAMES]
+ACTIVE_NAMES = PLUGIN_NAMES[:3]
+REGISTERED_ACTIVE_PLUGINS = REGISTERED_PLUGINS[:3]
+
+
 @zope.interface.implementer(interfaces.IEventConsumerClient)
 class EventConsumerStub:
     def __init__(self, config, success_chnl, error_chnl, **kwargs):
@@ -160,12 +167,10 @@ def installed_plugins(mocker):
         plugin_mock.load.return_value = _get_stub_class(name)
         return plugin_mock
 
-    return {
-        'xyz.event_consumer': mock_plugin('xyz.event_consumer'),
-        'xyz.enricher': mock_plugin('xyz.enricher'),
-        'xyz.publisher': mock_plugin('xyz.publisher'),
-        'xyz.runnable': mock_plugin('xyz.runnable'),
-    }
+    installed = {}
+    for plugin_name in REGISTERED_PLUGINS:
+        installed[plugin_name] = mock_plugin(plugin_name)
+    return installed
 
 
 @pytest.fixture
@@ -186,11 +191,8 @@ def plugin_kwargs():
 
 @pytest.fixture
 def inited_plugins(plugin_kwargs):
-    plugin_names = [
-        'event_consumer', 'enricher', 'publisher', 'runnable'
-    ]
     plugins = {}
-    for name in plugin_names:
+    for name in PLUGIN_NAMES:
         conf = _get_plugin_conf(name)
         plugins[name] = _get_stub_class(name)(conf, **plugin_kwargs)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,7 @@ Module for reusable pytest fixtures.
 
 import asyncio
 import logging
+import os
 
 import pkg_resources
 import pytest
@@ -99,22 +100,10 @@ def plugin_exc_mock():
 
 @pytest.fixture(scope='session')
 def config_file():
-    return ('[core]\n'
-            'plugins = ["xyz.event_consumer", "xyz.enricher",'
-            ' "xyz.publisher"]\n'
-            'debug = true\n'
-            '[core.logging]\n'
-            'level = "debug"\n'
-            'handlers = ["stream"]\n'
-            '[xyz]\n'
-            'a_key = "a_value"\n'
-            'b_key = "b_value"\n'
-            '[xyz.event_consumer]\n'
-            'a_key = "another_value"\n'
-            '[xyz.enricher]\n'
-            'd_key = "d_value"\n'
-            '[xyz.publisher]\n'
-            'c_key = "c_value"')
+    here = os.path.dirname(os.path.realpath(__file__))
+    filepath = os.path.join(here, 'fixtures/test-gordon.toml')
+    with open(filepath, 'r') as f:
+        return f.read()
 
 
 @pytest.fixture

--- a/tests/unit/fixtures/test-gordon.toml
+++ b/tests/unit/fixtures/test-gordon.toml
@@ -1,0 +1,23 @@
+# NOTICE - Test Fixture for Gordon Core
+# Gordon Core Config
+[core]
+plugins = ["xyz.event_consumer", "xyz.enricher", "xyz.publisher"]
+debug = true
+
+[core.logging]
+level = "debug"
+handlers = ["stream"]
+
+# Plugin Config
+[xyz]
+a_key = "a_value"
+b_key = "b_value"
+
+[xyz.event_consumer]
+a_key = "another_value"
+
+[xyz.enricher]
+d_key = "d_value"
+
+[xyz.publisher]
+c_key = "c_value"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -177,7 +177,7 @@ def test_gather_runnable_plugins(patches, exp_plugins, exp_mock_call,
 
 
 @pytest.mark.asyncio
-async def test_run_plugins(inited_plugins, mocker, monkeypatch):
+async def test_run_plugins(inited_plugins):
     """Run all installed plugins."""
     await main._run(inited_plugins.values(), debug=True)
 
@@ -236,7 +236,7 @@ def test_run_cli(has_active_plugins, exp_log_count, errors, installed_plugins,
 
 def test_run_cli_raise_exceptions(loaded_config, installed_plugins, caplog,
                                   setup_mock, mock_plugins_loader,
-                                  plugin_exc_mock, monkeypatch, mocker):
+                                  plugin_exc_mock):
     """Raise plugin exceptions when not in debug mode via CLI."""
     loaded_config['core']['debug'] = False
     setup_mock.return_value = loaded_config

--- a/tests/unit/test_plugins_loader.py
+++ b/tests/unit/test_plugins_loader.py
@@ -245,8 +245,7 @@ def test_load_plugins(mock_iter_entry_points, loaded_config, installed_plugins,
         assert any([p.config == plugin_obj.config for p in exp_inited_plugins])
 
 
-def test_load_plugins_none_loaded(mocker, installed_plugins, plugin_kwargs,
-                                  exp_inited_plugins):
+def test_load_plugins_none_loaded(mocker, installed_plugins, plugin_kwargs):
     """Return empty list when no plugins are found."""
     mock_iter_entry_points = mocker.MagicMock(pkg_resources.iter_entry_points)
     mock_iter_entry_points.return_value = []
@@ -258,10 +257,9 @@ def test_load_plugins_none_loaded(mocker, installed_plugins, plugin_kwargs,
     assert [] == installed_plugins == inited_names == errors
 
 
-def test_load_plugins_exceptions(installed_plugins, exp_inited_plugins,
-                                 loaded_config, mock_iter_entry_points,
-                                 plugin_exc_mock, plugin_kwargs, mocker,
-                                 monkeypatch):
+def test_load_plugins_exceptions(installed_plugins, loaded_config,
+                                 mock_iter_entry_points, plugin_exc_mock,
+                                 plugin_kwargs, mocker, monkeypatch):
     """Loading plugin exceptions are returned."""
     inited_plugins_mock = mocker.MagicMock(
         plugins_loader._init_plugins, autospec=True)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

* Update interface definitions for [naming consistency](https://github.com/spotify/gordon-janitor/commit/44f8fa7adc24d8c94aad7189f67ba710482a07a5) & [previously discussed improvements](https://github.com/spotify/gordon-gcp/pull/11#discussion_r181187199). Updates to gordon-gcp interface implementation are required ([an example](https://github.com/spotify/gordon-gcp/blob/develop/src/gordon_gcp/plugins/enricher.py#L244)).
* Add functionality to run installed and activated plugins. This is essentially fork-lifted from [the janitor](https://github.com/spotify/gordon-janitor/commit/adccc9390885e4b48bbb94fd1ebe65dd7fcec902); once this is merged, the janitor's plugin_loader can be removed and this module be imported into its `main` module. Apologies: I did some test cleanup and was too deep into it before I realized that it should be its own commit(s); I was able to separate some out easily into subsequent commits.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

The running of plugins functionality is similar to the [janitor](https://github.com/spotify/gordon-janitor/commit/adccc9390885e4b48bbb94fd1ebe65dd7fcec902#diff-9bc1630266f0f427305e2ff8457ac0e5), but notably different in the following way:

It will run any plugin (whether it implements the 3 interfaces or is a generic one) that has an implemented async `run` method. Our [interface definitions](https://github.com/spotify/gordon/commit/8ed770bbecf9ba05433c9a51abed47b6d380dce6) has only the event consumer defining an async `run` method, so therefore only that one will be started from `main`. The other two will be kicked off once the channel routing logic is implemented (forthcoming).

I did this because I'd like the ability to use generic plugins that don't necessarily implement a prescribed interface. An example: From our product area demo a month or so ago, I created a little HTTP server to do dynamic log level changes while the service is still running (i.e. a `POST` request to an endpoint could update the gordon service logger from `info` to `debug`). After watching a talk at PyCon 2018 on [making deployable applications](https://hynek.me/talks/deploy-friendly/), I got inspiration to make this a proper plugin (with other features, like a liveness and readyness health endpoints, being able to see event messages in flight & dump their history, etc). I'll write a little RFC up to go into more detail, but that's the motivation here.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add logic to start installed + configured plugins.
```

@spotify/alf 