### PR TITLE
Add initial routing logic for event messages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,12 @@ main
 
 .. autofunction:: gordon.main.setup
 
+router
+------
+
+.. automodule:: gordon.router
+.. autoclass:: gordon.router.GordonRouter
+
 
 plugins_loader
 --------------

--- a/gordon/router.py
+++ b/gordon/router.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Core message routing logic for the plugins within Gordon Service.
+
+Messages received on the success channel will be routed to the next
+designated plugin phase. For example, a message that has a ``consume``
+phase will be routed to the installed enricher provider (or publisher
+provider if no enricher provider is installed).
+
+If a message fails its next phase, its phase will be updated to ``drop``
+and routed to the event consumer provider for cleanup.
+
+.. attention::
+
+    The :class:`GordonRouter` only supports the following two phase
+    routes:
+
+    1. consume -> enrich -> publish -> done
+    2. consume -> publish -> done
+
+    Future releases may support more configurable phase routings.
+
+"""
+
+import asyncio
+import logging
+
+from gordon import interfaces
+
+
+# TODO/NOTE (lynn): This is a temporary helper function to alias
+#                   entrypoints of plugins to a common name. In the
+#                   future, plugin interfaces will be updated to have a
+#                   common name for their entrypoint.
+def _set_plugin_entrypoint_aliases(plugin_dict):
+    # e.g. enricher_inst.process => enricher_inst.handle_message
+    entrypoints = {
+        'enricher': 'process',
+        'publisher': 'publish_changes',
+        'event_consumer': 'cleanup',
+    }
+    for plugin_name, func in entrypoints.items():
+        try:
+            plugin = plugin_dict[plugin_name]
+        except KeyError:  # if no enricher
+            continue
+        entry_point = getattr(plugin, func)
+        setattr(plugin, 'handle_message', entry_point)
+    return plugin_dict
+
+
+class GordonRouter:
+    """Route messages to the appropriate plugin destination.
+
+    .. attention::
+
+        `error_channel` is currently not used in this router, and may
+        be removed entirely from all interface definitions.
+
+    Args:
+        success_channel (asyncio.Queue): A sink for successfully
+            processed :class:`gordon.interfaces.IEventMessage` s.
+        error_channel (asyncio.Queue): A sink for
+            :class:`gordon.interfaces.IEventMessage` s that were not
+            processed due to problems.
+        plugins (dict): Implemented plugin provider names mapped to
+            their instantiated objects.
+    """
+    # TODO (lynn): Ideally this is configurable/extendable in future
+    #              iterations of gordon.
+    PHASE_TO_PLUGIN_MAPPER = {
+        'enrich': 'enricher',
+        'publish': 'publisher',
+        'cleanup': 'event_consumer',
+    }
+    FINAL_PHASES = ('cleanup',)
+
+    def __init__(self, success_channel, error_channel, plugins):
+        self.success_channel = success_channel
+        self.error_channel = error_channel
+        self.plugins = _set_plugin_entrypoint_aliases(plugins)
+        self.phase_route = self._setup_phase_route()
+
+    # TODO (lynn): Ideally this is configurable/extendable in future
+    #              iterations of gordon.
+    def _setup_phase_route(self):
+        route = {
+            'consume': 'publish',
+            'publish': 'cleanup',
+            'cleanup': 'cleanup',
+        }
+        if 'enricher' in self.plugins:
+            route['consume'] = 'enrich'
+            route['enrich'] = 'publish'
+        return route
+
+    def _get_next_phase(self, event_msg):
+        try:
+            next_phase = self.phase_route[event_msg.phase]
+            msg = f'Routing message {event_msg} to phase "{next_phase}".'
+            logging.debug(msg)
+
+        except KeyError:
+            msg = (f'Message "{event_msg}" has an unknown phase: '
+                   f'"{event_msg.phase}". Dropping message.')
+            logging.error(msg)
+            next_phase = 'cleanup'
+        return next_phase
+
+    async def _route(self, event_msg, next_phase=None):
+        if not interfaces.IEventMessage.providedBy(event_msg):
+            msg = (f'Ignoring message "{event_msg}". Does not correctly '
+                   'implement `IEventMessage`.')
+            logging.warn(msg)
+            return
+
+        if not next_phase:
+            next_phase = self._get_next_phase(event_msg)
+
+        event_msg.update_phase(next_phase)
+        next_plugin_name = self.PHASE_TO_PLUGIN_MAPPER[next_phase]
+        plugin = self.plugins[next_plugin_name]
+
+        try:
+            await plugin.handle_message(event_msg)
+            # don't add a successfully dropped message back onto channel
+            if next_phase not in self.FINAL_PHASES:
+                msg = f'Adding message "{event_msg}" to success channel.'
+                event_msg.append_to_history(msg, event_msg.phase)
+                await self.success_channel.put(event_msg)
+
+        except Exception as e:
+            msg = f'Dropping message "{event_msg}" due to exception: "{e}"'
+            event_msg.append_to_history(msg, event_msg.phase)
+            logging.warn(msg, exc_info=e)
+            await self._route(event_msg, 'cleanup')
+
+    async def _poll_channel(self):
+        while True:
+            event_msg = await self.success_channel.get()
+
+            # graceful shutdown
+            if event_msg is None:
+                msg = 'Received TERM signal, shutting down router...'
+                logging.info(msg)
+                # TODO (lynn): potentially propagate signal all plugins
+                #              to clean up rather than just breaking
+                break
+
+            await self._route(event_msg)
+
+    async def run(self):
+        """Entrypoint to route messages between plugins."""
+        logging.info('Starting message router...')
+        loop = asyncio.get_event_loop()
+        loop.create_task(self._poll_channel())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,18 +37,20 @@ REGISTERED_ACTIVE_PLUGINS = REGISTERED_PLUGINS[:3]
 
 @zope.interface.implementer(interfaces.IEventConsumerClient)
 class EventConsumerStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_channel, error_channel, **kwargs):
         self.config = config
-        self.success_chnl = success_chnl
-        self.error_chnl = error_chnl
+        self.success_channel = success_channel
+        self.error_channel = error_channel
         self._mock_run_count = 0
+        self._mock_cleanup_count = 0
 
     async def run(self):
         await asyncio.sleep(0)
         self._mock_run_count += 1
 
-    async def cleanup(self):
-        pass
+    async def cleanup(self, event_msg):
+        await asyncio.sleep(0)
+        self._mock_cleanup_count += 1
 
     async def shutdown(self):
         pass
@@ -56,13 +58,15 @@ class EventConsumerStub:
 
 @zope.interface.implementer(interfaces.IEnricherClient)
 class EnricherStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_channel, error_channel, **kwargs):
         self.config = config
-        self.success_chnl = success_chnl
-        self.error_chnl = error_chnl
+        self.success_channel = success_channel
+        self.error_channel = error_channel
+        self._mock_process_count = 0
 
-    async def process(self):
-        pass
+    async def process(self, event_msg):
+        await asyncio.sleep(0)
+        self._mock_process_count += 1
 
     async def shutdown(self):
         pass
@@ -70,23 +74,25 @@ class EnricherStub:
 
 @zope.interface.implementer(interfaces.IPublisherClient)
 class PublisherStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_channel, error_channel, **kwargs):
         self.config = config
-        self.success_chnl = success_chnl
-        self.error_chnl = error_chnl
+        self.success_channel = success_channel
+        self.error_channel = error_channel
+        self._mock_publish_changes_count = 0
 
-    async def publish_changes(self):
-        pass
+    async def publish_changes(self, event_msg):
+        await asyncio.sleep(0)
+        self._mock_publish_changes_count += 1
 
     async def shutdown(self):
         pass
 
 
 class GenericStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_channel, error_channel, **kwargs):
         self.config = config
-        self.success_chnl = success_chnl
-        self.error_chnl = error_chnl
+        self.success_channel = success_channel
+        self.error_channel = error_channel
         self._mock_run_count = 0
 
     async def run(self):
@@ -181,11 +187,11 @@ def caplog(caplog):
     return caplog
 
 
-@pytest.fixture(scope='session')
-def plugin_kwargs():
+@pytest.fixture
+def plugin_kwargs(event_loop):
     return {
-        'success_chnl': asyncio.Queue(),
-        'error_chnl': asyncio.Queue(),
+        'success_channel': asyncio.Queue(),
+        'error_channel': asyncio.Queue(),
     }
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -176,10 +176,24 @@ def test_gather_runnable_plugins(patches, exp_plugins, exp_mock_call,
     assert exp_mock_call == mock_log_or_exit_on_exc.call_count
 
 
+def test_gather_implemented_providers(inited_plugins):
+    implemented = main._gather_implemented_providers(inited_plugins.values())
+
+    inited_plugins.pop('runnable')
+
+    assert inited_plugins == implemented
+
+
 @pytest.mark.asyncio
-async def test_run_plugins(inited_plugins):
+async def test_run_plugins(inited_plugins, mocker, monkeypatch):
     """Run all installed plugins."""
-    await main._run(inited_plugins.values(), debug=True)
+    async def mock_run(*args, **kwargs):
+        await asyncio.sleep(0)
+
+    mock_router = mocker.Mock()
+    monkeypatch.setattr(mock_router, 'run', mock_run)
+
+    await main._run(inited_plugins.values(), mock_router, debug=True)
 
     assert 1 == inited_plugins['event_consumer']._mock_run_count
     assert 1 == inited_plugins['runnable']._mock_run_count

--- a/tests/unit/test_plugins_loader.py
+++ b/tests/unit/test_plugins_loader.py
@@ -59,7 +59,7 @@ def plugin_config():
     }
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def exp_inited_plugins(plugin_config, plugin_kwargs):
     return [
         conftest.EventConsumerStub(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import zope.interface
+
+from gordon import interfaces
+from gordon import router
+
+
+@pytest.fixture()
+def router_inst(inited_plugins, plugin_kwargs):
+    inited_plugins.pop('runnable')
+    router_inst = router.GordonRouter(plugins=inited_plugins, **plugin_kwargs)
+    return router_inst
+
+
+@zope.interface.implementer(interfaces.IEventMessage)
+class EventMsgStub:
+    def __init__(self, mocker):
+        self.msg_id = 1234
+        self.phase = None
+        self._mock_update_phase_count = 0
+        self._mock_append_to_history = 0
+
+    def update_phase(self, new_phase):
+        self.phase = new_phase
+        self._mock_update_phase_count += 1
+
+    def append_to_history(self, *args, **kwargs):
+        self._mock_append_to_history += 1
+
+    def __repr__(self):
+        return f'EventMsgStub(msg_id={self.msg_id})'
+
+
+@pytest.fixture
+def event_msg(mocker):
+    msg = EventMsgStub(mocker)
+    msg.phase = 'consume'
+    return msg
+
+
+@pytest.mark.parametrize('enricher', [True, False])
+def test_init_router(enricher, inited_plugins, plugin_kwargs):
+    inited_plugins.pop('runnable')
+    if not enricher:
+        inited_plugins.pop('enricher')
+
+    router_inst = router.GordonRouter(plugins=inited_plugins, **plugin_kwargs)
+
+    exp_phase_route = {
+        'consume': 'publish',
+        'publish': 'cleanup',
+        'cleanup': 'cleanup'
+    }
+    if enricher:
+        exp_phase_route['consume'] = 'enrich'
+        exp_phase_route['enrich'] = 'publish'
+
+    assert exp_phase_route == router_inst.phase_route
+    for _, plugin in router_inst.plugins.items():
+        assert hasattr(plugin, 'handle_message')
+
+
+@pytest.mark.parametrize('current_phase,exp_next_phase', (
+    ('consume', 'enrich'),
+    ('its_not_a_phase_mom', 'cleanup'),
+))
+def test_get_next_phase(current_phase, exp_next_phase, router_inst, event_msg,
+                        caplog):
+    event_msg.phase = current_phase
+    next_phase = router_inst._get_next_phase(event_msg)
+
+    assert exp_next_phase == next_phase
+    assert 1 == len(caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('raises,exp_call_count,exp_log_count', (
+    (False, 0, 1),
+    (True, 1, 2),
+))
+async def test_route(raises, exp_call_count, exp_log_count, event_msg,
+                     router_inst, caplog, monkeypatch):
+    mock_process_call_count = 0
+    mock_process_call_args = []
+
+    async def mock_process(*args, **kwargs):
+        nonlocal mock_process_call_count
+        nonlocal mock_process_call_args
+
+        mock_process_call_count += 1
+        mock_process_call_args.append((args, kwargs))
+        if raises:
+            raise Exception('foo')
+
+    monkeypatch.setattr(
+        router_inst.plugins['enricher'], 'handle_message', mock_process)
+
+    await router_inst._route(event_msg)
+
+    assert 1 == mock_process_call_count
+    assert [((event_msg,), {})] == mock_process_call_args
+    assert 1 == event_msg._mock_append_to_history
+    assert exp_log_count == len(caplog.records)
+    actual_count = router_inst.plugins['event_consumer']._mock_cleanup_count
+    assert exp_call_count == actual_count
+
+
+@pytest.mark.asyncio
+async def test_route_invalid_msg(router_inst, caplog, mocker, monkeypatch):
+    event_msg = mocker.Mock()
+    mock_next_phase = mocker.Mock()
+    monkeypatch.setattr(router_inst, '_get_next_phase', mock_next_phase)
+
+    await router_inst._route(event_msg)
+
+    assert 1 == len(caplog.records)
+    mock_next_phase.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('enricher,raises', (
+    (True, False),
+    (True, True),
+    (False, True),
+    (False, False),
+))
+async def test_poll_channel(enricher, raises, router_inst, event_msg, caplog,
+                            monkeypatch):
+    if not enricher:
+        router_inst.phase_route.pop('enrich')
+        router_inst.phase_route['consume'] = 'publish'
+
+    if raises:
+        event_msg.phase = 'its_not_a_phase_mom'
+
+    mock_route_call_count = 0
+    mock_route_call_args = []
+
+    async def mock_route(*args, **kwargs):
+        nonlocal mock_route_call_count
+        nonlocal mock_route_call_args
+
+        mock_route_call_count += 1
+        mock_route_call_args.append((args, kwargs))
+
+    monkeypatch.setattr(router_inst, '_route', mock_route)
+
+    await router_inst.success_channel.put(event_msg)
+    await router_inst.success_channel.put(None)
+    await router_inst._poll_channel()
+
+    assert 1 == mock_route_call_count
+    assert [((event_msg,), {})] == mock_route_call_args
+
+
+@pytest.fixture
+def event_loop_mock(mocker, monkeypatch):
+    mock = mocker.Mock()
+    monkeypatch.setattr('gordon.router.asyncio.get_event_loop', mock)
+    return mock.return_value
+
+
+@pytest.mark.asyncio
+async def test_run(caplog, event_loop_mock, router_inst, mocker, monkeypatch):
+    poll_mock = mocker.Mock()
+    monkeypatch.setattr(router_inst, '_poll_channel', poll_mock)
+
+    await router_inst.run()
+
+    event_loop_mock.create_task.assert_called_once_with(poll_mock.return_value)
+    assert 1 == len(caplog.records)


### PR DESCRIPTION
Right now we just drop all messages that error out. The next commit(s) will add functionality to retry messages.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

Add initial routing logic for event messages.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->

N/A

**Special notes for your reviewer**:

This does not yet allow for retries; it will drop any event message that errors out. Retry logic will be added after the initial release of Gordon. However if retry logic is needed, then it can be handled within the plugins individually.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add initial routing logic for event messages.
```

@spotify/alf 
