### PR TITLE
Initial interface definitions for metrics.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,3 +38,18 @@ interfaces
 
 .. autointerface:: gordon.interfaces.IGenericPlugin
     :members:
+
+.. autointerface:: gordon.interfaces.IMetricRelay
+    :members:
+
+.. autointerface:: gordon.interfaces.ICounterMetric
+    :members:
+
+.. autointerface:: gordon.interfaces.ITimerMetric
+    :members:
+
+.. autointerface:: gordon.interfaces.IGaugeMetric
+    :members:
+
+.. autointerface:: gordon.interfaces.IGenericMetric
+    :members:

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -120,3 +120,46 @@ class IPublisherClient(IGenericPlugin):
         Args:
             event_msg (IEventMessage): Message ready to be sent to destination.
         """
+
+
+class IMetricRelay(Interface):
+    """Create and publish (push) metrics on demand."""
+
+    def incr(metric_name, value=1):
+        """Increment a metric. Create one if new."""
+
+    def timer(metric_name):
+        """Return a :class:`ITimerMetric`. Create one if new."""
+
+    def set_counter(metric_name, counter):
+        """Set a :class:`ICounterMetric` object to a given metric name."""
+
+    def set_timer(metric_name, timer):
+        """Set a :class:`ITimerMetric` to a given metric name."""
+
+
+class IGenericMetric(Interface):
+    """**Do not** implement this interface directly.
+
+    Use :class:`ICounterMetric` or :class:`ITimerMetric`
+    instead.
+    """
+
+
+class ICounterMetric(IGenericMetric):
+    """Monotonically increasing counter object."""
+
+    value = Attribute('Count value, must start at 0.')
+
+    def incr(value=1):
+        """Increase counter by 1 or a given amount."""
+
+
+class ITimerMetric(IGenericMetric):
+    """Timer for a block of code."""
+    value = Attribute('Timed value, must be a positive number.')
+
+
+class IGaugeMetric(IGenericMetric):
+    """An instantaneous measurement of a value."""
+    value = Attribute('Measured value.')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

Defines interfaces for metrics plugins.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

In discussing with @matt0bi, we kept this as generic as possible for now. It shouldn't be too difficult for someone to write - for instance - a [prometheus plugin](https://prometheus.io/docs/instrumenting/writing_clientlibs/) with their [python client](https://github.com/prometheus/client_python).

What @matt0bi and I imagine is within gordon core, it would load the metrics provider (very similar to how I approached it [here](https://github.com/spotify/gordon/pull/18/files#diff-6ef2c41f2a81ebf1e2f3f7c8065b9160R151)). If it doesn't find any, it would look to a `metrics.py` module (that's inside of core) to provide a metrics object.  Within `metrics.py`, it will try to import [`aioshumway`](https://github.com/spotify/aioshumway/blob/master/aioshumway/__init__.py#L86), and if it can't, it will default to a object that just logs out any metrics given. 

This allows us to not have to separately package an interface implementation for aioshumway. We'd add `extras_require={'aioshumway': ['aioshumway']}` and then `pip install gordon['aioshumway']` similar to how to do with [ulogger](https://github.com/spotify/ulogger/blob/master/setup.py#L103).

The intended API of the implemented `aioshumway` interface (and default metric logger interface) would be pretty much exactly how we use shumway already:

```python
metrics = aioshumway.MetricRelay('gordon')  # or a logger with the same API
# initialize available plugins w/ metrics object during loading, similar to the channels

# implements publisher interface
class SomePublisher:
    def __init__(self, config, ..., metrics):
        self.config = config
        self.metrics = metrics

    def publish_changes(self, event_msg):
        # do some publishing
        await self.metrics.incr('records-published', len(records))
```

Since [`incr`](https://github.com/spotify/aioshumway#initialize-a-counter-with-a-value) behavior in aioshumway does not yet emit the metrics, the interface implementation in `metrics.py` will have to overwrite the `incr` method to call `emit` right afterwords. This is future-proofing a little bit, allowing future metrics implementations that are pull-based (which prometheus is by default) to work, while still automatically emitting our own metrics. Sorry if that's confusing... 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add interface definitions for a metrics plugin.
```

@spotify/alf 