### PR TITLE
Update plugin_loader to load metrics plugin; Add FFWD metrics plugin

### DIFF
--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -15,3 +15,11 @@ bar = baz
 ["foo.plugin"]
 # specific plugin config within "foo" package
 baz = bla
+
+
+[metrics]
+provider = "gordon.metrics.ffwd"
+key = "gordon-service"
+time_unit = 1E9
+ffwd_ip = "10.99.0.1"
+ffwd_port = 19000

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -147,10 +147,8 @@ class ITimer(Interface):
     async def __aexit__(type, value, traceback):
         """Exit context manager to stop timing."""
 
-
     async def start():
         """Start timing."""
-
 
     async def stop():
         """End timing."""

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -125,14 +125,32 @@ class IPublisherClient(IGenericPlugin):
 class IMetricRelay(Interface):
     """Manage Gordon metrics."""
 
-    def incr(metric_name, value=1):
+    async def incr(metric_name, value=1, **kwargs):
         """Increase counter metric by 1 or a given amount."""
 
-    def timer(metric_name):
-        """Time a block of code."""
+    def timer(metric_name, **kwargs):
+        """Get a timer object which implements ITimer."""
 
-    def set(metric_name, value):
+    async def set(metric_name, value, **kwargs):
         """Set a gauge metric to a given value."""
 
-    def cleanup():
+    async def cleanup(**kwargs):
         """Perform cleanup tasks related to metrics handling."""
+
+
+class ITimer(Interface):
+    """Timer support]ing both manual operation and use as a context manager."""
+
+    async def __aenter__():
+        """Enter context manager to start timing."""
+
+    async def __aexit__(type, value, traceback):
+        """Exit context manager to stop timing."""
+
+
+    async def start():
+        """Start timing."""
+
+
+    async def stop():
+        """End timing."""

--- a/gordon/metrics/ffwd.py
+++ b/gordon/metrics/ffwd.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import time
+
+import zope.interface
+
+from gordon import interfaces
+
+
+class FfwdClientProtocol(asyncio.DatagramProtocol):
+    """Protocol for sending one-off messages to ffwd.
+
+    Args:
+        message (bytes): Message for ffwd agent.
+    """
+    def __init__(self, message):
+        self.message = message
+        self.transport = None
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.transport.sendto(self.message)
+        self.transport.close()
+
+
+class UDPClient:
+    """Client for sending UDP datagrams.
+
+    Args:
+        ip (str): Destination IP address.
+        port (int): Destination port.
+        loop (asyncio.event_loop): (optional) Event loop.
+    """
+    def __init__(self, ip, port, loop=None):
+        self.ip = ip
+        self.port = port
+        self.loop = loop or asyncio.get_event_loop()
+
+    async def send(self, metric):
+        """Transform metric to JSON bytestring and send to server.
+
+        Args:
+            metric (dict): Complete metric to send as JSON.
+        """
+        message = json.dumps(metric).encode('utf-8')
+        await self.loop.create_datagram_endpoint(
+            lambda: FfwdClientProtocol(message),
+            remote_addr=(self.ip, self.port))
+
+
+@zope.interface.implementer(interfaces.ITimer)
+class FfwdTimer:
+    """ITimer implementation which sends UDP messages to FFWD on completion.
+
+    Args:
+        metric (dict): Dict representation of the metric to send.
+        udp_client (UDPClient): A metric sending client.
+        time_unit (number): (optional) Scale time unit for use with time.time()
+            (example: 1E9 to send nanoseconds).
+    """
+    def __init__(self, metric, udp_client, time_unit=1):
+        self.metric = metric
+        self.udp_client = udp_client
+        self.time_unit = time_unit
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.stop()
+
+    async def start(self):
+        self._start_time = time.time()
+
+    async def stop(self):
+        time_elapsed = (time.time() - self._start_time) * self.time_unit
+        self.metric['value'] = time_elapsed
+        await self.udp_client.send(self.metric)
+
+
+@zope.interface.implementer(interfaces.IMetricRelay)
+class FfwdRelay:
+    """IMetricRelay implementation which sends metrics to FFWD immediately.
+
+    Args:
+        config (dict): Required keys:
+            key (str): A key to identify the service as a whole.
+            ffwd_ip (str): ffwd IP address.
+            ffwd_port (int): ffwd port number.
+            time_unit (number): Scale unit to use with timers.
+    """
+    def __init__(self, config):
+        self.key = config['key']
+        self.udp_client = UDPClient(config['ffwd_ip'], config['ffwd_port'])
+        self.time_unit = config['time_unit']
+
+    def _create_metric(self, metric_name, value, **kwargs):
+        attrs = kwargs.get('attrs') or {}
+        tags = kwargs.get('tags') or []
+
+        attrs['what'] = metric_name
+        return {
+            'key': self.key,
+            'attributes': attrs,
+            'value': value,
+            'type': 'metric',
+            'tags': tags
+        }
+
+    async def incr(self, metric_name, value=1, **kwargs):
+        await self.set(metric_name, value, **kwargs)
+
+    def timer(self, metric_name, **kwargs):
+        metric = self._create_metric(metric_name, None, **kwargs)
+        return FfwdTimer(metric, self.udp_client, self.time_unit)
+
+    async def set(self, metric_name, value, **kwargs):
+        metric = self._create_metric(metric_name, value, **kwargs)
+        await self.udp_client.send(metric)
+
+    async def cleanup(self):
+        pass

--- a/gordon/plugins_loader.py
+++ b/gordon/plugins_loader.py
@@ -186,6 +186,14 @@ def _gather_installed_plugins():
     return gathered_plugins
 
 
+def _get_metrics_plugin(config, installed_plugins):
+    metrics_config = config.get('metrics', {})
+    for plugin_name, plugin in installed_plugins.items():
+        if plugin_name == metrics_config.get('provider', {}):
+            plugin_class = plugin.load()
+            return plugin_class(metrics_config)
+
+
 def load_plugins(config, plugin_kwargs):
     """
     Discover and instantiate plugins.
@@ -202,6 +210,10 @@ def load_plugins(config, plugin_kwargs):
         config.
     """
     installed_plugins = _gather_installed_plugins()
+    metrics_plugin = _get_metrics_plugin(config, installed_plugins)
+    if metrics_plugin:
+        plugin_kwargs['metrics'] = metrics_plugin
+
     active_plugins = _get_activated_plugins(config, installed_plugins)
     if not active_plugins:
         return [], [], []

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,10 +37,11 @@ REGISTERED_ACTIVE_PLUGINS = REGISTERED_PLUGINS[:3]
 
 @zope.interface.implementer(interfaces.IEventConsumerClient)
 class EventConsumerStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_chnl, error_chnl, metrics=None):
         self.config = config
         self.success_chnl = success_chnl
         self.error_chnl = error_chnl
+        self.metrics = metrics
         self._mock_run_count = 0
 
     async def run(self):
@@ -56,10 +57,11 @@ class EventConsumerStub:
 
 @zope.interface.implementer(interfaces.IEnricherClient)
 class EnricherStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_chnl, error_chnl, metrics=None):
         self.config = config
         self.success_chnl = success_chnl
         self.error_chnl = error_chnl
+        self.metrics = metrics
 
     async def process(self):
         pass
@@ -70,10 +72,11 @@ class EnricherStub:
 
 @zope.interface.implementer(interfaces.IPublisherClient)
 class PublisherStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_chnl, error_chnl, metrics=None):
         self.config = config
         self.success_chnl = success_chnl
         self.error_chnl = error_chnl
+        self.metrics = metrics
 
     async def publish_changes(self):
         pass
@@ -83,10 +86,11 @@ class PublisherStub:
 
 
 class GenericStub:
-    def __init__(self, config, success_chnl, error_chnl, **kwargs):
+    def __init__(self, config, success_chnl, error_chnl, metrics=None):
         self.config = config
         self.success_chnl = success_chnl
         self.error_chnl = error_chnl
+        self.metrics = metrics
         self._mock_run_count = 0
 
     async def run(self):

--- a/tests/unit/metrics/test_ffwd.py
+++ b/tests/unit/metrics/test_ffwd.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numbers
+
+import pytest
+
+from gordon.metrics import ffwd
+
+
+def test_ffwd_protocol_connection_made(mocker):
+    """Message sends and connection closes."""
+    mock_transport = mocker.Mock()
+    message = 'Testing message!'
+
+    protocol = ffwd.FfwdClientProtocol(message)
+    protocol.connection_made(mock_transport)
+
+    mock_transport.sendto.assert_called_once_with(message)
+    mock_transport.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_udp_client_send(mocker):
+    """Sends serialized metric using FfwdClientProtocol."""
+    mock_loop = mocker.Mock()
+
+    actual_func = None
+    actual_addr = None
+
+    async def mock_create_datagram_endpoint(func, remote_addr):
+        nonlocal actual_func
+        nonlocal actual_addr
+        actual_func = func
+        actual_addr = remote_addr
+
+    mock_loop.create_datagram_endpoint = mock_create_datagram_endpoint
+
+    udp_client = ffwd.UDPClient('1.2.3.4', '5678', mock_loop)
+    await udp_client.send({'an': 'object'})
+
+    actual_protocol = actual_func()
+    assert isinstance(actual_protocol, ffwd.FfwdClientProtocol)
+    assert ('1.2.3.4', '5678') == actual_addr
+    assert b'{"an": "object"}' == actual_protocol.message
+
+
+@pytest.fixture
+def mock_udp_client_and_metrics_sent(mocker):
+    metrics_sent = []
+
+    async def mock_send(metric):
+        nonlocal metrics_sent
+        metrics_sent.append(metric)
+
+    mock_udp_client = mocker.Mock()
+    mock_udp_client.send = mock_send
+    return mock_udp_client, metrics_sent
+
+
+@pytest.fixture
+def timer_and_metrics_sent(mock_udp_client_and_metrics_sent):
+    mock_udp_client, metrics_sent = mock_udp_client_and_metrics_sent
+    metric = {'a': 'metric', 'value': None}
+    timer = ffwd.FfwdTimer(metric, mock_udp_client)
+    return timer, metrics_sent
+
+
+@pytest.mark.asyncio
+async def test_ffwdtimer_manual(timer_and_metrics_sent):
+    """Times when operated manually."""
+    timer, metrics_sent = timer_and_metrics_sent
+    await timer.start()
+    assert isinstance(timer._start_time, numbers.Number)
+
+    await timer.stop()
+    assert len(metrics_sent) == 1
+    assert 'metric' == metrics_sent[0]['a']
+    assert 0 < metrics_sent[0]['value']
+
+
+@pytest.mark.asyncio
+async def test_ffwdtimer_as_context_manager(timer_and_metrics_sent):
+    """Times as a context manager."""
+    timer, metrics_sent = timer_and_metrics_sent
+    async with timer as t:
+        assert isinstance(t._start_time, numbers.Number)
+
+    assert len(metrics_sent) == 1
+    assert 'metric' == metrics_sent[0]['a']
+    assert 0 < metrics_sent[0]['value']
+
+
+@pytest.fixture
+def test_config(mocker, monkeypatch):
+    monkeypatch.setattr(ffwd, 'UDPClient', mocker.Mock)
+    return {
+        'key': 'service-name',
+        'ffwd_ip': '1.2.3.4',
+        'ffwd_port': '5678',
+        'time_unit': 1E9
+    }
+
+
+@pytest.mark.parametrize('key,name,val,attrs,tags', [
+    ('service-name', 'metric-name', 10, None, None),
+    ('other-name', 'other-metric', 6.243289, {'hostname': 'dns-host-3'}, None),
+    ('service-name', 'other-metric', 500000, None, ['v40']),
+    ('service-name', 'other-metric', 500000, {'type': 'active'}, ['v40'])
+])
+def test_ffwdrelay_create_metric(test_config, key, name, val, attrs, tags):
+    """Creates metric for all arguments."""
+    test_config['key'] = key
+    relay = ffwd.FfwdRelay(test_config)
+    actual = relay._create_metric(name, val, attrs=attrs, tags=tags)
+
+    attrs = attrs or {}
+    attrs.update({'what': name})
+    expected = {
+        'key': key,
+        'attributes': attrs,
+        'value': val,
+        'type': 'metric',
+        'tags': tags or []
+    }
+    assert expected == actual
+
+
+@pytest.fixture
+def ffwdrelay_and_metrics_sent(test_config, mock_udp_client_and_metrics_sent):
+    mock_udp_client, metrics_sent = mock_udp_client_and_metrics_sent
+    relay = ffwd.FfwdRelay(test_config)
+    relay.udp_client = mock_udp_client
+    return relay, metrics_sent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('attrs,tags', [
+    (None, None),
+    ({'hostname': 'dns-host-3'}, None),
+    (None, ['v40']),
+    ({'type': 'active'}, ['v40'])
+])
+async def test_ffwdrelay_incr(ffwdrelay_and_metrics_sent, attrs, tags):
+    """Initializes and sends metrics."""
+    ffwdrelay, metrics_sent = ffwdrelay_and_metrics_sent
+    expected = [
+        ffwdrelay._create_metric('some-counter', 1, attrs=attrs, tags=tags)
+    ]
+    await ffwdrelay.incr('some-counter', attrs=attrs, tags=tags)
+    assert expected == metrics_sent
+
+
+@pytest.fixture
+def ffwdrelay(ffwdrelay_and_metrics_sent):
+    return ffwdrelay_and_metrics_sent[0]
+
+
+@pytest.mark.parametrize('attrs,tags', [
+    (None, None),
+    ({'hostname': 'dns-host-3'}, None),
+    (None, ['v40']),
+    ({'type': 'active'}, ['v40'])
+])
+def test_ffwdrelay_timer(ffwdrelay, attrs, tags):
+    """Returns initialized timer."""
+    expected_metric = ffwdrelay._create_metric(
+        'some-timer', None, attrs=attrs, tags=tags)
+    actual = ffwdrelay.timer('some-timer', attrs=attrs, tags=tags)
+    assert isinstance(actual, ffwd.FfwdTimer)
+    assert expected_metric == actual.metric
+    assert ffwdrelay.time_unit == actual.time_unit
+    assert ffwdrelay.udp_client == actual.udp_client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('attrs,tags', [
+    (None, None),
+    ({'hostname': 'dns-host-3'}, None),
+    (None, ['v40']),
+    ({'type': 'active'}, ['v40'])
+])
+async def test_ffwdrelay_set(ffwdrelay_and_metrics_sent, attrs, tags):
+    """Sends metric."""
+    ffwdrelay, metrics_sent = ffwdrelay_and_metrics_sent
+    expected = [
+        ffwdrelay._create_metric('some-counter', 42, attrs=attrs, tags=tags)
+    ]
+    await ffwdrelay.set('some-counter', 42, attrs=attrs, tags=tags)
+    assert expected == metrics_sent
+
+
+@pytest.mark.asyncio
+async def test_cleanup(ffwdrelay):
+    """Raises no errors."""
+    await ffwdrelay.cleanup()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This PR updates the plugin loader to pick and load a metrics and to pass it to all the other plugins. It also implements a simple FFWD-compatible metrics plugin that adheres to the IMetricRelay interface and which can be used to push metrics to FFWD. 

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

The FFWD plugin is included by default in order to avoid creating another repository. Since FFWD is our current choice for metrics, it makes sense if we include and support it as part of Gordon. Because users select the metrics plugin through the configuration file, including it doesn't mean users are forced to use FFWD.

The FFWD plugin doesn't use or depend on [aioshumway](https://github.com/spotify/aioshumway/). We opted for this in order to break away from the shumway interface, which we wouldn't use in any way apart from the `MetricRelay.emit` method, and to have one less dependency, which also affords us more flexibility. 

This PR doesn't include the default metrics plugin, which, instead of emitting metrics, will log them to stdout. The next PR will. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable plugin loader to load metrics plugin.
Add FFWD-compatible metrics plugin.
```

@spotify/alf 