### PR TITLE
Update plugin_loader to load metrics plugin; Add FFWD metrics plugin

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -48,6 +48,11 @@ core
 
     If ``false``, Gordon will exit out if it can't load one or more plugins.
 
+.. option:: metrics="STR"
+
+    The metrics provider to use. Depending on the provider, more
+    configuration may be needed. See provider implementation for details.
+
 
 core.logging
 ~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ User's Guide
    config
    plugins
    api
+   metrics
 
 
 Project Information

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,21 @@
+Metrics Implementations
+==============================
+
+.. currentmodule:: gordon
+
+ffwd
+---------------
+
+.. automodule:: gordon.metrics.ffwd
+
+.. autoclass:: gordon.metrics.ffwd.SimpleFfwdRelay
+    :members:
+
+.. autoclass:: gordon.metrics.ffwd.FfwdTimer
+    :members:
+
+.. autoclass:: gordon.metrics.ffwd.UDPClient
+    :members:
+
+.. autoclass:: gordon.metrics.ffwd.UDPClientProtocol
+    :members:

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -2,6 +2,7 @@
 [core]
 plugins = ["foo.plugin"]
 debug = false
+metrics = "ffwd"
 
 [core.logging]
 level = "info"

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -61,7 +61,7 @@ class IGenericPlugin(Interface):
     """
     phase = Attribute('Plugin phase')
 
-    def __init__(config, success_channel, error_channel, metrics=None):
+    def __init__(config, success_channel, error_channel, metrics):
         """Initialize an EventClient object.
 
         Args:

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -125,14 +125,50 @@ class IPublisherClient(IGenericPlugin):
 class IMetricRelay(Interface):
     """Manage Gordon metrics."""
 
-    def incr(metric_name, value=1):
-        """Increase counter metric by 1 or a given amount."""
+    async def incr(metric_name, value=1, context=None, **kwargs):
+        """Increase a metric by 1 or a given amount.
 
-    def timer(metric_name):
-        """Time a block of code."""
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (int): (optional) Value with which to increase the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'remote-host': '1.2.3.4'}
+        """
 
-    def set(metric_name, value):
-        """Set a gauge metric to a given value."""
+    def timer(metric_name, context=None, **kwargs):
+        """Get a timer object which implements ITimer.
 
-    def cleanup():
+        Args:
+            metric_name (str): Identifier of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'unit': 'seconds'}
+        """
+
+    async def set(metric_name, value, context=None, **kwargs):
+        """Set a metric to a given value.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (number): The value of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'app-version': '1.5.3'}
+        """
+
+    async def cleanup(**kwargs):
         """Perform cleanup tasks related to metrics handling."""
+
+
+class ITimer(Interface):
+    """Timer supporting both manual operation and use as a context manager."""
+
+    async def __aenter__():
+        """Enter context manager to start timing."""
+
+    async def __aexit__(type, value, traceback):
+        """Exit context manager to stop timing."""
+
+    async def start():
+        """Start timing."""
+
+    async def stop():
+        """End timing."""

--- a/gordon/main.py
+++ b/gordon/main.py
@@ -188,7 +188,7 @@ def run(config_root):
         'success_channel': asyncio.Queue(),
         'error_channel': asyncio.Queue(),
     }
-    plugin_names, plugins, errors = plugins_loader.load_plugins(
+    plugin_names, plugins, errors, metrics = plugins_loader.load_plugins(
         config, channels)
     if errors:
         for err_plugin, exc in errors:

--- a/gordon/metrics/__init__.py
+++ b/gordon/metrics/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/gordon/metrics/ffwd.py
+++ b/gordon/metrics/ffwd.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+Gordon ships with a simple `ffwd <https://github.com/spotify/ffwd>`_
+metrics implementation, which can be enabled via configuration. This
+module contains the SimpleFfwdRelay, and all required classes that it
+uses to send messsages to the ffwd daemon via UDP.
+
+The `SimpleFfwdRelay` requires no configuration, but can be customized.
+The defaults that may be overridden are shown below.
+
+.. code-block:: ini
+
+    [ffwd]
+    # to identify the service creating metrics
+    key = 'gordon-service'
+
+    # the address of the ffwd daemon (see: UDPClient)
+    ip = "127.0.0.9"
+    port = 19000
+
+    # a scaling factor for timing (see: FfwdTimer)
+    time_unit = 1E9
+
+"""
+
+import asyncio
+import json
+import time
+
+import zope.interface
+
+from gordon import interfaces
+
+
+class UDPClientProtocol(asyncio.DatagramProtocol):
+    """Protocol for sending one-off messages via UDP.
+
+    Args:
+        message (bytes): Message for ffwd agent.
+    """
+    def __init__(self, message):
+        self.message = message
+        self.transport = None
+
+    def connection_made(self, transport):
+        """Create connection, use to send message and close.
+
+        Args:
+            transport (asyncio.DatagramTransport): Transport used for sending.
+        """
+        self.transport = transport
+        self.transport.sendto(self.message)
+        self.transport.close()
+
+
+class UDPClient:
+    """Client for sending UDP datagrams.
+
+    Args:
+        ip (str): (optional) Destination IP address (default: 127.0.0.1).
+        port (int): (optional) Destination port (default: 9000).
+        loop (asyncio.AbstractEventLoop impl): (optional) Event loop.
+    """
+
+    DEFAULT_IP = '127.0.0.1'
+    DEFAULT_PORT = 19000
+
+    def __init__(self, ip=None, port=None, loop=None):
+        self.ip = ip or self.DEFAULT_IP
+        self.port = port or self.DEFAULT_PORT
+        self.loop = loop or asyncio.get_event_loop()
+
+    async def send(self, metric):
+        """Transform metric to JSON bytestring and send to server.
+
+        Args:
+            metric (dict): Complete metric to send as JSON.
+        """
+        message = json.dumps(metric).encode('utf-8')
+        await self.loop.create_datagram_endpoint(
+            lambda: UDPClientProtocol(message),
+            remote_addr=(self.ip, self.port))
+
+
+@zope.interface.implementer(interfaces.ITimer)
+class FfwdTimer:
+    """Timer which sends UDP messages to FFWD on completion.
+
+    Args:
+        metric (dict): Dict representation of the metric to send.
+        udp_client (UDPClient): A metric sending client.
+        time_unit (number): (optional) Scale time unit for use with
+            time.perf_counter(), for example: 1E9 to send nanoseconds.
+    """
+    def __init__(self, metric, udp_client, time_unit=None):
+        self.metric = metric
+        self.udp_client = udp_client
+        self.time_unit = time_unit or 1
+
+    async def __aenter__(self):
+        """Enter context manager to start timing."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args):
+        """Exit context manager to stop timing."""
+        await self.stop()
+
+    async def start(self):
+        """Start timer."""
+        self._start_time = time.perf_counter()
+
+    async def stop(self):
+        """Stop timer."""
+        time_elapsed = time.perf_counter() - self._start_time
+        self.metric['value'] = time_elapsed * self.time_unit
+        await self.udp_client.send(self.metric)
+
+
+@zope.interface.implementer(interfaces.IMetricRelay)
+class SimpleFfwdRelay:
+    """Metrics relay which sends to FFWD immediately.
+
+    The relay does no client-side aggregation and metrics are
+    emitted immediately. The relay uses a combination of the `key and
+    attributes fields <https://github.com/spotify/ffwd/tree/master/
+    modules/json>`_ to semantically identify metrics in ffwd.
+
+    Args:
+        config (dict): Configuration with optional keys described above.
+    """
+    def __init__(self, config):
+        self.key = config.get('key', 'gordon-service')
+        self.udp_client = UDPClient(
+            config.get('ffwd_ip'), config.get('ffwd_port'))
+        self.time_unit = config.get('time_unit')
+
+    def _create_metric(self, metric_name, value, context, **kwargs):
+        attrs = context or {}
+        attrs['what'] = metric_name
+
+        metric = {
+            'key': self.key,
+            'attributes': attrs,
+            'value': value,
+            'type': 'metric'
+        }
+        return metric
+
+    async def incr(self, metric_name, value=1, context=None, **kwargs):
+        """Increase a metric by 1 or a given amount.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (int): (optional) Value with which to increase the metric
+                (default: 1).
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'remote-host': '1.2.3.4'}
+        """
+        await self.set(metric_name, value, context, **kwargs)
+
+    def timer(self, metric_name, context=None, **kwargs):
+        """Create a FfwdTimer.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'unit': 'seconds'}
+        """
+        metric = self._create_metric(metric_name, None, context, **kwargs)
+        return FfwdTimer(metric, self.udp_client, self.time_unit)
+
+    async def set(self, metric_name, value, context=None, **kwargs):
+        """Set a metric to a given value.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (number): The value of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'app-version': '1.5.3'}
+        """
+        metric = self._create_metric(metric_name, value, context, **kwargs)
+        await self.udp_client.send(metric)
+
+    async def cleanup(self):
+        """Not used."""
+        pass

--- a/gordon/plugins_loader.py
+++ b/gordon/plugins_loader.py
@@ -59,6 +59,7 @@ import logging
 import pkg_resources
 
 from gordon import exceptions
+from gordon.metrics import ffwd
 
 
 PLUGIN_NAMESPACE = 'gordon.plugins'
@@ -191,7 +192,9 @@ def _get_metrics_plugin(config, installed_plugins):
     if not metrics_provider:
         return
 
-    metrics_config = config.get(metrics_provider)
+    metrics_config = config.get(metrics_provider, {})
+    if metrics_provider == 'ffwd':
+        return ffwd.SimpleFfwdRelay(metrics_config)
 
     for plugin_name, plugin in installed_plugins.items():
         if metrics_provider == plugin_name:

--- a/gordon/plugins_loader.py
+++ b/gordon/plugins_loader.py
@@ -227,8 +227,9 @@ def load_plugins(config, plugin_kwargs):
 
     active_plugins = _get_activated_plugins(config, installed_plugins)
     if not active_plugins:
-        return [], [], []
+        return [], [], [], None
     plugin_namespaces = _get_plugin_config_keys(active_plugins)
     plugin_configs = _load_plugin_configs(plugin_namespaces, config)
-    return _init_plugins(
+    plugin_names, plugins, errors = _init_plugins(
         active_plugins, installed_plugins, plugin_configs, plugin_kwargs)
+    return plugin_names, plugins, errors, metrics_plugin

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -41,7 +41,6 @@ class EventConsumerStub:
         self.config = config
         self.success_channel = success_channel
         self.error_channel = error_channel
-        self.metrics = metrics
         self._mock_run_count = 0
         self._mock_cleanup_count = 0
 
@@ -64,7 +63,6 @@ class EnricherStub:
         self.success_channel = success_channel
         self.error_channel = error_channel
         self._mock_process_count = 0
-        self.metrics = metrics
 
     async def process(self, event_msg):
         await asyncio.sleep(0)
@@ -81,7 +79,6 @@ class PublisherStub:
         self.success_channel = success_channel
         self.error_channel = error_channel
         self._mock_publish_changes_count = 0
-        self.metrics = metrics
 
     async def publish_changes(self, event_msg):
         await asyncio.sleep(0)
@@ -96,7 +93,6 @@ class GenericStub:
         self.config = config
         self.success_channel = success_channel
         self.error_channel = error_channel
-        self.metrics = metrics
         self._mock_run_count = 0
 
     async def run(self):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,10 +37,11 @@ REGISTERED_ACTIVE_PLUGINS = REGISTERED_PLUGINS[:3]
 
 @zope.interface.implementer(interfaces.IEventConsumerClient)
 class EventConsumerStub:
-    def __init__(self, config, success_channel, error_channel, **kwargs):
+    def __init__(self, config, success_channel, error_channel, metrics=None):
         self.config = config
         self.success_channel = success_channel
         self.error_channel = error_channel
+        self.metrics = metrics
         self._mock_run_count = 0
         self._mock_cleanup_count = 0
 
@@ -58,11 +59,12 @@ class EventConsumerStub:
 
 @zope.interface.implementer(interfaces.IEnricherClient)
 class EnricherStub:
-    def __init__(self, config, success_channel, error_channel, **kwargs):
+    def __init__(self, config, success_channel, error_channel, metrics=None):
         self.config = config
         self.success_channel = success_channel
         self.error_channel = error_channel
         self._mock_process_count = 0
+        self.metrics = metrics
 
     async def process(self, event_msg):
         await asyncio.sleep(0)
@@ -74,11 +76,12 @@ class EnricherStub:
 
 @zope.interface.implementer(interfaces.IPublisherClient)
 class PublisherStub:
-    def __init__(self, config, success_channel, error_channel, **kwargs):
+    def __init__(self, config, success_channel, error_channel, metrics=None):
         self.config = config
         self.success_channel = success_channel
         self.error_channel = error_channel
         self._mock_publish_changes_count = 0
+        self.metrics = metrics
 
     async def publish_changes(self, event_msg):
         await asyncio.sleep(0)
@@ -89,10 +92,11 @@ class PublisherStub:
 
 
 class GenericStub:
-    def __init__(self, config, success_channel, error_channel, **kwargs):
+    def __init__(self, config, success_channel, error_channel, metrics=None):
         self.config = config
         self.success_channel = success_channel
         self.error_channel = error_channel
+        self.metrics = metrics
         self._mock_run_count = 0
 
     async def run(self):

--- a/tests/unit/metrics/test_ffwd.py
+++ b/tests/unit/metrics/test_ffwd.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numbers
+
+import pytest
+
+from gordon.metrics import ffwd
+
+
+def test_ffwd_protocol_connection_made(mocker):
+    """Message sends and connection closes."""
+    mock_transport = mocker.Mock()
+    message = 'Testing message!'
+
+    protocol = ffwd.UDPClientProtocol(message)
+    protocol.connection_made(mock_transport)
+
+    mock_transport.sendto.assert_called_once_with(message)
+    mock_transport.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_udp_client_send(mocker):
+    """Sends serialized metric using FfwdClientProtocol."""
+    mock_loop = mocker.Mock()
+
+    actual_func = None
+    actual_addr = None
+
+    async def mock_create_datagram_endpoint(func, remote_addr):
+        nonlocal actual_func
+        nonlocal actual_addr
+        actual_func = func
+        actual_addr = remote_addr
+
+    mock_loop.create_datagram_endpoint = mock_create_datagram_endpoint
+
+    udp_client = ffwd.UDPClient('1.2.3.4', '5678', mock_loop)
+    await udp_client.send({'an': 'object'})
+
+    actual_protocol = actual_func()
+    assert isinstance(actual_protocol, ffwd.UDPClientProtocol)
+    assert ('1.2.3.4', '5678') == actual_addr
+    assert b'{"an": "object"}' == actual_protocol.message
+
+
+@pytest.fixture
+def mock_udp_client_and_metrics_sent(mocker):
+    metrics_sent = []
+
+    async def mock_send(metric):
+        nonlocal metrics_sent
+        metrics_sent.append(metric)
+
+    mock_udp_client = mocker.Mock()
+    mock_udp_client.send = mock_send
+    return mock_udp_client, metrics_sent
+
+
+@pytest.fixture
+def timer_and_metrics_sent(mock_udp_client_and_metrics_sent):
+    mock_udp_client, metrics_sent = mock_udp_client_and_metrics_sent
+    metric = {'a': 'metric', 'value': None}
+    timer = ffwd.FfwdTimer(metric, mock_udp_client)
+    return timer, metrics_sent
+
+
+@pytest.mark.asyncio
+async def test_ffwdtimer_manual(timer_and_metrics_sent):
+    """Times when operated manually."""
+    timer, metrics_sent = timer_and_metrics_sent
+    await timer.start()
+    assert isinstance(timer._start_time, numbers.Number)
+
+    await timer.stop()
+    assert 1 == len(metrics_sent)
+    assert 'metric' == metrics_sent[0]['a']
+    assert 0 < metrics_sent[0]['value']
+
+
+@pytest.mark.asyncio
+async def test_ffwdtimer_as_context_manager(timer_and_metrics_sent):
+    """Times as a context manager."""
+    timer, metrics_sent = timer_and_metrics_sent
+    async with timer as t:
+        assert isinstance(t._start_time, numbers.Number)
+
+    assert 1 == len(metrics_sent)
+    assert 'metric' == metrics_sent[0]['a']
+    assert 0 < metrics_sent[0]['value']
+
+
+@pytest.fixture
+def test_config():
+    return {
+        'key': 'service-name',
+        'ffwd_ip': '1.2.3.4',
+        'ffwd_port': '5678',
+        'time_unit': 1E9
+    }
+
+
+TEST_KEY_NAME_VAL = [
+    ('service-name', 'metric-name', 10),
+    ('other-name', 'metric-name', 6.243289),
+    ('service-name', 'other-metric', 500000),
+    ('service-name', 'other-metric', -20),
+    ('service-name', 'other-metric', 10),
+]
+
+
+TEST_KWARGS = [
+    {'context': None, 'tags': None, 'other_extraneous_kwarg': 'ignored!'},
+    {'context': {'remote-host': 'dns-host-3'}, 'tags': None},
+    {'context': None, 'tags': ['v40']},
+    {'context': {'type': 'active'}, 'tags': ['v40']},
+    {'context': {'type': 'active'}, 'extraneous_kwarg': 'should be ignored'}
+]
+
+
+@pytest.mark.parametrize('key_name_val,kwargs', zip(
+    TEST_KEY_NAME_VAL, TEST_KWARGS))
+def test_ffwdrelay_create_metric(test_config, key_name_val, kwargs):
+    """Creates metric for all arguments."""
+    key, name, val = key_name_val
+    test_config['key'] = key
+    relay = ffwd.SimpleFfwdRelay(test_config)
+    actual = relay._create_metric(name, val, **kwargs)
+
+    attrs = kwargs['context'] or {}
+    attrs.update({'what': name})
+    expected = {
+        'key': key,
+        'attributes': attrs,
+        'value': val,
+        'type': 'metric'
+    }
+    assert expected == actual
+
+
+@pytest.fixture
+def ffwdrelay_and_metrics_sent(test_config, mock_udp_client_and_metrics_sent):
+    mock_udp_client, metrics_sent = mock_udp_client_and_metrics_sent
+    relay = ffwd.SimpleFfwdRelay(test_config)
+    relay.udp_client = mock_udp_client
+    return relay, metrics_sent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('kwargs', TEST_KWARGS)
+async def test_ffwdrelay_incr(ffwdrelay_and_metrics_sent, kwargs):
+    """Creates and sends metrics with value 1."""
+    ffwdrelay, metrics_sent = ffwdrelay_and_metrics_sent
+    expected = [ffwdrelay._create_metric('some-increasing-value', 1, **kwargs)]
+    await ffwdrelay.incr('some-increasing-value', **kwargs)
+    assert expected == metrics_sent
+
+
+@pytest.fixture
+def ffwdrelay(ffwdrelay_and_metrics_sent):
+    return ffwdrelay_and_metrics_sent[0]
+
+
+@pytest.mark.parametrize('kwargs', TEST_KWARGS)
+def test_ffwdrelay_timer(ffwdrelay, kwargs):
+    """Returns initialized timer."""
+    expected_metric = ffwdrelay._create_metric('some-timer', None, **kwargs)
+    actual = ffwdrelay.timer('some-timer', **kwargs)
+    assert isinstance(actual, ffwd.FfwdTimer)
+    assert expected_metric == actual.metric
+    assert ffwdrelay.time_unit == actual.time_unit
+    assert ffwdrelay.udp_client == actual.udp_client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('kwargs', TEST_KWARGS)
+async def test_ffwdrelay_set(ffwdrelay_and_metrics_sent, kwargs):
+    """Creates and sends metric with arbitrary value."""
+    ffwdrelay, metrics_sent = ffwdrelay_and_metrics_sent
+    expected = [
+        ffwdrelay._create_metric('some-measure', 42, **kwargs)
+    ]
+    await ffwdrelay.set('some-measure', 42, **kwargs)
+    assert expected == metrics_sent
+
+
+@pytest.mark.asyncio
+async def test_cleanup(ffwdrelay):
+    """Raises no errors."""
+    await ffwdrelay.cleanup()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -227,7 +227,7 @@ def test_run_cli(has_active_plugins, exp_log_count, errors, installed_plugins,
             conftest.EnricherStub({}, success, error),
             conftest.PublisherStub({}, success, error)
         ]
-    mock_plugins_loader.return_value = names, _plugins, errors
+    mock_plugins_loader.return_value = names, _plugins, errors, mocker.Mock()
     _run_mock = mocker.Mock()
     monkeypatch.setattr('gordon.main._run', _run_mock)
     _log_or_exit_mock = mocker.Mock()
@@ -250,14 +250,15 @@ def test_run_cli(has_active_plugins, exp_log_count, errors, installed_plugins,
 
 def test_run_cli_raise_exceptions(loaded_config, installed_plugins, caplog,
                                   setup_mock, mock_plugins_loader,
-                                  plugin_exc_mock):
+                                  plugin_exc_mock, mocker):
     """Raise plugin exceptions when not in debug mode via CLI."""
     loaded_config['core']['debug'] = False
     setup_mock.return_value = loaded_config
 
     names = ['event_consumer', 'enricher']
     errors = [('not_a_plugin', plugin_exc_mock)]
-    mock_plugins_loader.return_value = names, installed_plugins, errors
+    mock_plugins_loader.return_value = names, installed_plugins, errors, \
+        mocker.Mock()
 
     runner = CliRunner()
     result = runner.invoke(main.run)

--- a/tests/unit/test_plugins_loader.py
+++ b/tests/unit/test_plugins_loader.py
@@ -239,7 +239,7 @@ def test_gather_installed_plugins(mock_iter_entry_points, installed_plugins):
 def test_load_plugins(mock_iter_entry_points, loaded_config, installed_plugins,
                       exp_inited_plugins, plugin_kwargs):
     """Plugins are loaded and instantiated with their config."""
-    inited_names, installed_plugins, errors = plugins_loader.load_plugins(
+    inited_names, installed_plugins, errors, _ = plugins_loader.load_plugins(
         loaded_config, plugin_kwargs)
 
     assert 3 == len(inited_names) == len(installed_plugins)
@@ -255,7 +255,7 @@ def test_load_plugins_none_loaded(mocker, installed_plugins, plugin_kwargs):
 
     loaded_config = {'core': {}}
 
-    inited_names, installed_plugins, errors = plugins_loader.load_plugins(
+    inited_names, installed_plugins, errors, _ = plugins_loader.load_plugins(
         loaded_config, plugin_kwargs)
     assert [] == installed_plugins == inited_names == errors
 
@@ -272,7 +272,7 @@ def test_load_plugins_exceptions(installed_plugins, loaded_config,
         conftest.REGISTERED_PLUGINS, inited_plugins_mock, exc)
     monkeypatch.setattr(plugins_loader, '_init_plugins', inited_plugins_mock)
 
-    inited_names, installed_plugins, errors = plugins_loader.load_plugins(
+    inited_names, installed_plugins, errors, _ = plugins_loader.load_plugins(
         loaded_config, plugin_kwargs)
     assert 1 == len(errors)
 
@@ -306,16 +306,16 @@ def test_load_plugins_with_metrics(plugins_incl_metrics, loaded_config,
                                    metrics_mock):
     """Plugins are loaded and instantiated with their config and metrics."""
     loaded_config['core'].update({'metrics': metrics_mock.name})
-    inited_names, installed_plugins, errors = plugins_loader.load_plugins(
+    names, installed_plugins, errors, metrics = plugins_loader.load_plugins(
         loaded_config, plugin_kwargs)
 
     # if metrics were included, len() would be 4
-    assert 3 == len(inited_names) == len(installed_plugins)
+    assert 3 == len(names) == len(installed_plugins)
     for plugin_obj in installed_plugins:
         assert not isinstance(plugin_obj, MetricRelayStub)
         assert is_instance_of_stub(plugin_obj)
         assert any([p.config == plugin_obj.config for p in exp_inited_plugins])
-        assert isinstance(plugin_obj.metrics, MetricRelayStub)
+        assert isinstance(metrics, MetricRelayStub)
 
 
 def test_get_metrics_returns_ffwd(loaded_config, plugins_incl_metrics):

--- a/tests/unit/test_plugins_loader.py
+++ b/tests/unit/test_plugins_loader.py
@@ -21,6 +21,7 @@ import zope.interface
 from gordon import exceptions
 from gordon import interfaces
 from gordon import plugins_loader
+from gordon.metrics import ffwd
 from tests.unit import conftest
 
 
@@ -315,6 +316,13 @@ def test_load_plugins_with_metrics(plugins_incl_metrics, loaded_config,
         assert is_instance_of_stub(plugin_obj)
         assert any([p.config == plugin_obj.config for p in exp_inited_plugins])
         assert isinstance(plugin_obj.metrics, MetricRelayStub)
+
+
+def test_get_metrics_returns_ffwd(loaded_config, plugins_incl_metrics):
+    loaded_config['core'].update({'metrics': 'ffwd'})
+    actual = plugins_loader._get_metrics_plugin(
+        loaded_config, plugins_incl_metrics)
+    assert isinstance(actual, ffwd.SimpleFfwdRelay)
 
 
 def test_get_metrics_returns_plugin(metrics_mock, plugins_incl_metrics):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This PR updates the plugin loader to pick and load a metrics and to pass it to all the other plugins. It also implements a simple FFWD-compatible metrics plugin that adheres to the IMetricRelay interface and which can be used to push metrics to FFWD. 

Note, this is the same PR as #21 but with the branch changed from `add_metrics` to `feature/add_metrics` to comply with the contributing guide.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

The FFWD plugin is included by default in order to avoid creating another repository. Since FFWD is our current choice for metrics, it makes sense if we include and support it as part of Gordon. Because users select the metrics plugin through the configuration file, including it doesn't mean users are forced to use FFWD.

The FFWD plugin doesn't use or depend on [aioshumway](https://github.com/spotify/aioshumway/). We opted for this in order to break away from the shumway interface, which we wouldn't use in any way apart from the `MetricRelay.emit` method, and to have one less dependency, which also affords us more flexibility. 

This PR doesn't include the default metrics plugin, which, instead of emitting metrics, will log them to stdout. The next PR will. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable plugin loader to load metrics plugin.
Add FFWD-compatible metrics plugin.
```

@spotify/alf 