### PR TITLE
[WIP] Add metric logger metric relay implementation

### DIFF
--- a/gordon/metrics/log.py
+++ b/gordon/metrics/log.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Gordon ships with a default IMetricRelay implementation, which
+outputs metrics to the application logger using the standard
+library `logging` module.
+
+This implementation is used by default if no other IMetricRelay
+implementation is loaded and chosen.
+
+The default configuration that can be overriden is shown below.
+
+.. code-block:: ini
+
+    [metrics-logger]
+    # One of the log levels available from the stdlib logging module.
+    log_level = 'info'
+    # A scaling factor for timing (see: LogTimer)
+    time_unit = 1
+"""
+
+import collections
+import logging
+import time
+
+import zope.interface
+
+from gordon import interfaces
+
+# TODO: update plugin loader to load metrics logger as default
+
+
+@zope.interface.implementer(interfaces.ITimer)
+class LogTimer:
+    """Timer that outputs metrics to the logger.
+
+    Args:
+        metric (dict): Metric to output.
+        logger (.LoggerAdapter): Object used for outputting metrics.
+        time_unit (number): (optional) Scale time unit for use with
+            time.perf_counter(), for example: 1E9 to send nanoseconds.
+    """
+    def __init__(self, metric, logger, time_unit=1):
+        self.metric = metric
+        self.logger = logger
+        self.time_unit = time_unit
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.stop()
+
+    async def start(self):
+        """Start the timer."""
+        self._start_time = time.perf_counter()
+
+    async def stop(self):
+        """Stop the timer and output the time delta to the logger."""
+        time_elapsed = (
+            time.perf_counter() - self._start_time) * self.time_unit
+        self.metric['value'] = time_elapsed
+        self.logger.log(self.metric)
+
+
+class LoggerAdapter:
+    """Configurable adapter that formats and outputs metrics.
+
+    Args:
+        level (str): Log level at which to output metric.
+    """
+    LOGFMT = '[{metric_name}] value: {value}'
+
+    def __init__(self, level):
+        self.level = level
+        self._logger = logging.getLogger('gordon.metrics-logger')
+
+    def log(self, metric):
+        """Format and output metric.
+
+        Args:
+            metric (dict): Complete metric.
+        """
+        message = self.LOGFMT.format(**metric)
+        if metric['context']:
+            message += ' context: {context}'.format(context=metric['context'])
+        getattr(self._logger, self.level.lower())(message)
+
+
+@zope.interface.implementer(interfaces.IMetricRelay)
+class LogRelay:
+    """Manage metrics that get output to a logger.
+
+    Args:
+        config (dict): Required keys:
+            level (str): Log level of metrics log messages.
+            time_unit (number): (optional) Scale time unit for use with
+                LogTimer, for example: 1E9 to send nanoseconds.
+    """
+    def __init__(self, config):
+        level = config.get('log_level', 'info')
+        self.time_unit = config.get('time_unit', 1)
+        self.logger = LoggerAdapter(level)
+        self.counters = collections.defaultdict(int)
+
+    def _create_metric(self, metric_name, value, context, **kwargs):
+        context = context or {}
+
+        return {
+            'metric_name': metric_name,
+            'value': value,
+            'context': context
+        }
+
+    async def incr(self, metric_name, value=1, context=None, **kwargs):
+        """Increase a metric counter by ``value`` and output result.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (number): (optional) Value with which to increase the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'remote-host': '1.2.3.4'}
+        """
+        self.counters[metric_name] += value
+        await self.set(metric_name, self.counters[metric_name], context,
+                       **kwargs)
+
+    def timer(self, metric_name, context=None, **kwargs):
+        """Create a LogTimer.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'unit': 'milliseconds'}
+        """
+        metric = self._create_metric(metric_name, None, context, **kwargs)
+        return LogTimer(metric, self.logger, self.time_unit)
+
+    async def set(self, metric_name, value, context=None, **kwargs):
+        """Output ``metric_name`` with ``value``.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (number): (optional) Value of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'app-version': '1.5.4'}
+        """
+        metric = self._create_metric(metric_name, value, context, **kwargs)
+        self.logger.log(metric)
+
+    async def cleanup(self):
+        """Not used."""
+        pass

--- a/tests/unit/metrics/test_log.py
+++ b/tests/unit/metrics/test_log.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numbers
+
+import pytest
+
+from gordon.metrics import log
+
+
+@pytest.mark.parametrize('context,context_str', [
+    ({'source': 'external'}, ' context: {\'source\': \'external\'}'),
+    ({}, '')
+])
+def test_logger_adapter_log_outputs_message(caplog, context, context_str):
+    """Metric is formatted and output to log."""
+    logger_adapter = log.LoggerAdapter('INFO')
+    metric = {
+        'metric_name': 'events',
+        'value': 12.12,
+        'context': context
+        }
+    logger_adapter.log(metric)
+    assert 1 == len(caplog.records)
+    expected_log = '[events] value: 12.12' + context_str
+    assert expected_log == caplog.records[0].msg
+
+
+@pytest.fixture
+def mock_logger_adapter(mocker):
+    return mocker.Mock(log.LoggerAdapter)
+
+
+@pytest.fixture
+def log_timer(mock_logger_adapter):
+    metric = {'metric_name': 'test-metric', 'value': 13.05, 'context': {}}
+    return log.LogTimer(metric, mock_logger_adapter, 1)
+
+
+@pytest.mark.asyncio
+async def test_log_timer_manual(log_timer):
+    """Times when using start/stop interface."""
+
+    await log_timer.start()
+    assert isinstance(log_timer._start_time, numbers.Number)
+
+    await log_timer.stop()
+    assert 1 == log_timer.logger.log.call_count
+    actual_metric = log_timer.logger.log.mock_calls[0][1][0]
+    assert 'test-metric' == actual_metric['metric_name']
+    assert {} == actual_metric['context']
+    assert 0 < actual_metric['value']
+
+
+@pytest.mark.asyncio
+async def test_log_timer_as_context_manager(log_timer):
+    """Times when using as a context manager."""
+    async with log_timer as t:
+        assert isinstance(t._start_time, numbers.Number)
+    actual_metric = log_timer.logger.log.mock_calls[0][1][0]
+    assert 1 == log_timer.logger.log.call_count
+    assert 'test-metric' == actual_metric['metric_name']
+    assert {} == actual_metric['context']
+    assert 0 < actual_metric['value']
+
+
+@pytest.fixture
+def relay_config():
+    return {
+        'time_unit': 1,
+        'log_level': 'info',
+    }
+
+
+@pytest.mark.parametrize('name,val,context', [
+    ('a-metric', 12, None),
+    ('nother-metric', 0.0003, {'source': 'internal'}),
+])
+def test_logrelay_create_metric(relay_config, name, val, context):
+    """Create a metric dictionary."""
+    relay = log.LogRelay(relay_config)
+    actual = relay._create_metric(name, val, context=context)
+
+    expected = {
+        'metric_name': name,
+        'value': val,
+        'context': context or {}
+    }
+    assert expected == actual
+
+
+@pytest.fixture
+def mock_log_relay(monkeypatch, mocker, relay_config):
+    logger_mock = mocker.Mock(log.LoggerAdapter)
+    monkeypatch.setattr(log, 'LoggerAdapter', logger_mock)
+    return log.LogRelay(relay_config)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('context', [
+    {'source': 'perimiter'},
+    None
+])
+async def test_logrelay_incr(mock_log_relay, context):
+    """Initializes and outputs metrics to logger."""
+    expected_metric = mock_log_relay._create_metric('requests-recv', 601,
+                                                    context=context)
+    await mock_log_relay.incr('requests-recv', 601, context=context)
+
+    mock_log_relay.logger.log.assert_called_once_with(expected_metric)
+
+
+@pytest.mark.asyncio
+async def test_logrelay_incr_accumulation(mocker, mock_log_relay):
+    """MetricRelay.incr accumulates values."""
+    base_value = 441
+    incr = 10
+    expected_metric = mock_log_relay._create_metric('requests-recv',
+                                                    base_value, context=None)
+    expected_2nd_metric = mock_log_relay._create_metric(
+        'requests-recv', base_value + incr, context=None)
+    await mock_log_relay.incr('requests-recv', base_value)
+    await mock_log_relay.incr('requests-recv', incr)
+
+    assert base_value + incr == mock_log_relay.counters['requests-recv']
+    expected_calls = [
+        mocker.call(expected_metric),
+        mocker.call(expected_2nd_metric)
+    ]
+    mock_log_relay.logger.log.assert_has_calls(expected_calls)
+
+
+def test_logrelay_timer(mock_log_relay):
+    """Initialize and return a LogTimer object."""
+    expected_metric = mock_log_relay._create_metric('latency', None,
+                                                    context=None)
+    timer = mock_log_relay.timer('latency')
+    assert isinstance(timer, log.LogTimer)
+    assert expected_metric == timer.metric
+    assert timer.logger == mock_log_relay.logger
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('context', [
+    {'version': 'dev0'},
+    None
+])
+async def test_logrelay_set(mock_log_relay, context):
+    """Output single metric to logger."""
+    expected_metric = mock_log_relay._create_metric('latency', 451,
+                                                    context=context)
+    await mock_log_relay.set('latency', 451, context=context)
+
+    mock_log_relay.logger.log.assert_called_once_with(expected_metric)
+
+
+@pytest.mark.asyncio
+async def test_cleanup(mock_log_relay):
+    """Implemented, but a noop."""
+    assert await mock_log_relay.cleanup() is None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This PR implements the default metric relay, which outputs metrics to the logger.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

This PR is WIP because it's based off #22. I'll update this PR with any changes in #22 that affect the code here. I'll also update this PR with any comments from #22 that are relevant to this one. 

Note that because there's an outstanding comment in #22 about the plugin loader, I didn't touch that part in this PR. Once that's resolved, I'll update the code here to tackle the "plugin loader should load logger metrics by default" issue.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add default metric logger.
```

@spotify/alf 
