### PR TITLE
Replace plugin interfaces with generic functional interfaces

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,13 +33,10 @@ interfaces
 .. autointerface:: gordon.interfaces.IEventMessage
     :members:
 
-.. autointerface:: gordon.interfaces.IEventConsumerClient
+.. autointerface:: gordon.interfaces.IRunnable
     :members:
 
-.. autointerface:: gordon.interfaces.IEnricherClient
-    :members:
-
-.. autointerface:: gordon.interfaces.IPublisherClient
+.. autointerface:: gordon.interfaces.IMessageHandler
     :members:
 
 .. autointerface:: gordon.interfaces.IGenericPlugin

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -48,7 +48,7 @@ core
 
     If ``false``, Gordon will exit out if it can't load one or more plugins.
 
-.. option:: metrics="STR"
+.. option:: metrics=STR
 
     The metrics provider to use. Depending on the provider, more
     configuration may be needed. See provider implementation for details.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -68,3 +68,18 @@ core.logging
     .. note::
 
         If ``stackdriver`` is selected, ``ulogger[stackdriver]`` needs to be installed as its dependencies are not installed by default.
+
+
+core.route
+~~~~~~~~~~
+A table of key-value pairs of phases used to indicate the route the
+a message should take. All keys should correspond to either
+the `start_phase` attribute of a runnable plugin or the `phase` of a message
+handling plugin. Values may only correspond to `phase` of a message handling
+plugin.
+
+.. code-block:: ini
+
+    [core.route]
+    start_phase = "phase2"
+    phase2 = "phase3"

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -4,6 +4,10 @@ plugins = ["foo.plugin"]
 debug = false
 metrics = "ffwd"
 
+[core.route]
+consume = "publish"
+publish = "cleanup"
+
 [core.logging]
 level = "info"
 handlers = ["syslog"]

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -25,6 +25,9 @@ class IEventMessage(Interface):
     or cleanup in case of errors.
     """
 
+    msg_id = Attribute('Identifier for the event message instance.')
+    phase = Attribute('Variable phase of the event message.')
+
     def __init__(msg_id, data, history_log, phase=None):
         """Initialize an EventMessage.
 

--- a/gordon/interfaces.py
+++ b/gordon/interfaces.py
@@ -55,14 +55,26 @@ class IEventMessage(Interface):
 class IGenericPlugin(Interface):
     """**Do not** implement this interface directly.
 
-    Use :py:class:`gordon.interfaces.IEventConsumerClient`,
-    :py:class:`gordon.interfaces.IEnricherClient`,
-    or :py:class:`gordon.interfaces.IPublisherClient` instead.
+    Use :py:class:`gordon.interfaces.IRunnable`,
+    or :py:class:`gordon.interfaces.IMessageHandler` instead.
     """
-    phase = Attribute('Plugin phase')
 
-    def __init__(config, success_channel, error_channel, metrics):
-        """Initialize an EventClient object.
+    async def shutdown():
+        """Perform any actions required to gracefully shutdown plugin."""
+
+
+class IRunnable(IGenericPlugin):
+    """Runnable plugin to produce event messages for Gordon to process.
+
+    The plugin also has the ability to send :py:class:`gordon.interfaces
+    EventMessage` objects to both success and error channels. At least
+    one runnable plugin is required to run Gordon.
+    """
+
+    start_phase = Attribute('Starting phase for event messages.')
+
+    def __init__(config, success_channel, error_channel, metrics, **kwargs):
+        """Initialize a runnable plugin.
 
         Args:
             config (dict): Plugin-specific configuration.
@@ -73,52 +85,34 @@ class IGenericPlugin(Interface):
             metrics (obj): Optional obj used to emit metrics.
         """
 
-    async def shutdown():
-        """Gracefully shutdown plugin."""
-
-
-class IEventConsumerClient(IGenericPlugin):
-    """Client for ingesting push/pull events for Gordon to process.
-
-    The client also receives both successful and failed
-    :py:class:`gordon.interfaces.IEventMessage` objects from Gordon in order
-    to perform cleanup if needed.
-    """
-
     async def run():
         """Begin consuming messages using the provided event loop."""
 
-    async def cleanup(event_msg):
-        """Perform cleanup tasks related to a message.
 
-        Args:
-            event_msg (IEventMessage): Message at the end of its life cycle.
-        """
+class IMessageHandler(IGenericPlugin):
+    """Plugin which performs some operation on an event message.
 
-
-class IEnricherClient(IGenericPlugin):
-    """Client for processing (enriching) or filtering events received by Gordon.
-
-    Note that if no extra processing is required, the implementer can
-    immediately push the received event into the success_channel.
+    The Gordon core router will use its `phase_route` to direct messages
+    produced by any runnable plugins the appropriate message handling
+    plugins, identified by their phase attribute. At least
+    one message handling plugin is required to run Gordon.
     """
 
-    async def process(event_msg):
-        """Process message.
+    phase = Attribute('Plugin phase')
+
+    def __init__(config, metrics, **kwargs):
+        """Initialize a message handler.
 
         Args:
-            event_msg (IEventMessage): Message to process.
+            config (dict): Plugin-specific configuration.
+            metrics (obj): Obj used to emit metrics.
         """
 
-
-class IPublisherClient(IGenericPlugin):
-    """Client for publishing processed events to their destination."""
-
-    async def publish_changes(event_msg):
-        """Publish processed event to its destination.
+    async def handle_message(event_message):
+        """Perform some operation on or triggered by an event message.
 
         Args:
-            event_msg (IEventMessage): Message ready to be sent to destination.
+            event_message (IEventMessage): Message on which to operate.
         """
 
 

--- a/gordon/main.py
+++ b/gordon/main.py
@@ -139,8 +139,9 @@ def _gather_plugins_by_type(plugins, debug):
     return runnable_plugins, message_handling_plugins
 
 
-def _setup_message_router(plugins, success_channel, error_channel):
-    msg_router = router.GordonRouter(success_channel, error_channel, plugins)
+def _setup_router(config, plugins, success_channel, error_channel):
+    msg_router = router.GordonRouter(
+        config, success_channel, error_channel, plugins)
     return msg_router
 
 
@@ -174,7 +175,9 @@ def run(config_root):
         logging.info(f'Loaded {len(plugin_names)} plugins: {plugin_names}.')
 
     runnables, message_handlers = _gather_plugins_by_type(plugins, debug_mode)
-    msg_router = _setup_message_router(message_handlers, **channels)
+
+    route_config = config.get('core', {}).get('route', {})
+    msg_router = _setup_router(route_config, message_handlers, **channels)
 
     logging.info(f'Starting gordon v{version}...')
     loop = asyncio.get_event_loop()

--- a/gordon/main.py
+++ b/gordon/main.py
@@ -102,75 +102,50 @@ def _log_or_exit_on_exceptions(base_msg, exc, debug):
         raise SystemExit(1)
 
 
-def _assert_required_plugins(installed_plugins, debug):
-    # enricher not required
-    required_providers_available = {
-        'event_consumer': False,
-        'publisher': False,
-    }
-    for plugin in installed_plugins:
-        if interfaces.IEventConsumerClient.providedBy(plugin):
-            required_providers_available['event_consumer'] = True
-        elif interfaces.IPublisherClient.providedBy(plugin):
-            required_providers_available['publisher'] = True
-
-    missing = []
-    msg = ('The provider for the "{name}" interface is not configured for the '
-           'Gordon service or is not implemented.')
-    for provider, available in required_providers_available.items():
-        if not available:
-            exc = exceptions.MissingPluginError(msg.format(name=provider))
-            missing.append(exc)
-    if missing:
-        base_msg = 'Problem running plugins: '
-        _log_or_exit_on_exceptions(base_msg, missing, debug=debug)
-
-
-def _gather_runnable_plugins(plugins, debug):
-    plugins_to_run = []
+def _gather_plugins_by_type(plugins, debug):
+    runnable_plugins = []
+    message_handling_plugins = []
     for plugin in plugins:
-        if interfaces.IEventConsumerClient.providedBy(plugin):
-            # TODO (lynn): this should be switched out for adding
-            # the "verify interface implementation" ability. See
-            # https://docs.zope.org/zope.interface/verify.html
+        # TODO (lynn): these should be switched out for adding
+        # the "verify interface implementation" ability. See
+        # https://docs.zope.org/zope.interface/verify.html
+        if interfaces.IRunnable.providedBy(plugin):
             if not hasattr(plugin, 'run') or \
                     not asyncio.iscoroutinefunction(plugin.run):
                 msg = (f'Implemention "{plugin}" of the required '
-                       '"IEventConsumerClient" interface does not have the '
+                       '"IRunnable" interface does not have the '
                        'necessary `run` method.')
                 exc = exceptions.InvalidPluginError(msg)
                 _log_or_exit_on_exceptions(msg, exc, debug)
                 continue
-            plugins_to_run.append(plugin)
-        elif hasattr(plugin, 'run') and asyncio.iscoroutinefunction(plugin.run):
-            plugins_to_run.append(plugin)
+            runnable_plugins.append(plugin)
 
-    return plugins_to_run
+        if interfaces.IMessageHandler.providedBy(plugin):
+            if not hasattr(plugin, 'handle_message') or \
+                    not asyncio.iscoroutinefunction(plugin.handle_message):
+                msg = (f'Implemention "{plugin}" of the required '
+                       '"IMessageHandler" interface does not have the '
+                       'necessary `handle_message` method.')
+                exc = exceptions.InvalidPluginError(msg)
+                _log_or_exit_on_exceptions(msg, exc, debug)
+                continue
+            message_handling_plugins.append(plugin)
 
+    if not runnable_plugins or not message_handling_plugins:
+        msg = (f'At least one runnable plugin is required.')
+        exc = exceptions.MissingPluginError(msg)
+        _log_or_exit_on_exceptions(msg, [exc], debug=debug)
 
-def _gather_implemented_providers(plugins):
-    implemented = {}
-    for plugin in plugins:
-        if interfaces.IEventConsumerClient.providedBy(plugin):
-            implemented['event_consumer'] = plugin
-        elif interfaces.IEnricherClient.providedBy(plugin):
-            implemented['enricher'] = plugin
-        elif interfaces.IPublisherClient.providedBy(plugin):
-            implemented['publisher'] = plugin
-    return implemented
+    return runnable_plugins, message_handling_plugins
 
 
 def _setup_message_router(plugins, success_channel, error_channel):
-    implemented_plugins = _gather_implemented_providers(plugins)
-    msg_router = router.GordonRouter(
-        success_channel, error_channel, implemented_plugins)
+    msg_router = router.GordonRouter(success_channel, error_channel, plugins)
     return msg_router
 
 
-async def _run(plugins, msg_router, debug):
-    _assert_required_plugins(plugins, debug)
-    plugins_to_run = _gather_runnable_plugins(plugins, debug)
-    tasks = [p.run() for p in plugins_to_run]
+async def _run(runnable_plugins, msg_router, debug):
+    tasks = [p.run() for p in runnable_plugins]
     tasks.append(msg_router.run())
     await asyncio.gather(*tasks)
 
@@ -198,12 +173,13 @@ def run(config_root):
     if plugin_names:
         logging.info(f'Loaded {len(plugin_names)} plugins: {plugin_names}.')
 
-    msg_router = _setup_message_router(plugins, **channels)
+    runnables, message_handlers = _gather_plugins_by_type(plugins, debug_mode)
+    msg_router = _setup_message_router(message_handlers, **channels)
 
     logging.info(f'Starting gordon v{version}...')
     loop = asyncio.get_event_loop()
     try:
-        loop.create_task(_run(plugins, msg_router, debug_mode))
+        loop.create_task(_run(runnables, msg_router, debug_mode))
         loop.run_forever()
     finally:
         loop.stop()

--- a/gordon/router.py
+++ b/gordon/router.py
@@ -42,27 +42,6 @@ import logging
 from gordon import interfaces
 
 
-# TODO/NOTE (lynn): This is a temporary helper function to alias
-#                   entrypoints of plugins to a common name. In the
-#                   future, plugin interfaces will be updated to have a
-#                   common name for their entrypoint.
-def _set_plugin_entrypoint_aliases(plugin_dict):
-    # e.g. enricher_inst.process => enricher_inst.handle_message
-    entrypoints = {
-        'enricher': 'process',
-        'publisher': 'publish_changes',
-        'event_consumer': 'cleanup',
-    }
-    for plugin_name, func in entrypoints.items():
-        try:
-            plugin = plugin_dict[plugin_name]
-        except KeyError:  # if no enricher
-            continue
-        entry_point = getattr(plugin, func)
-        setattr(plugin, 'handle_message', entry_point)
-    return plugin_dict
-
-
 class GordonRouter:
     """Route messages to the appropriate plugin destination.
 
@@ -77,22 +56,16 @@ class GordonRouter:
         error_channel (asyncio.Queue): A sink for
             :class:`gordon.interfaces.IEventMessage` s that were not
             processed due to problems.
-        plugins (dict): Implemented plugin provider names mapped to
-            their instantiated objects.
+        plugins (list): Instantiated message handling plugins.
     """
     # TODO (lynn): Ideally this is configurable/extendable in future
     #              iterations of gordon.
-    PHASE_TO_PLUGIN_MAPPER = {
-        'enrich': 'enricher',
-        'publish': 'publisher',
-        'cleanup': 'event_consumer',
-    }
     FINAL_PHASES = ('cleanup',)
 
     def __init__(self, success_channel, error_channel, plugins):
         self.success_channel = success_channel
         self.error_channel = error_channel
-        self.plugins = _set_plugin_entrypoint_aliases(plugins)
+        self.phase_plugin_map = self._get_phase_plugin_map(plugins)
         self.phase_route = self._setup_phase_route()
 
     # TODO (lynn): Ideally this is configurable/extendable in future
@@ -103,10 +76,18 @@ class GordonRouter:
             'publish': 'cleanup',
             'cleanup': 'cleanup',
         }
-        if 'enricher' in self.plugins:
+        if 'enrich' in self.phase_plugin_map:
             route['consume'] = 'enrich'
             route['enrich'] = 'publish'
         return route
+
+    def _get_phase_plugin_map(self, plugins):
+        phase_map = {p.phase: p for p in plugins}
+        if not set(self.FINAL_PHASES) & set(phase_map):
+            msg = (f'None of {self.FINAL_PHASES} implemented, will default'
+                   'to dropping messages at these phases.')
+            logging.warn(msg)
+        return phase_map
 
     def _get_next_phase(self, event_msg):
         try:
@@ -116,7 +97,7 @@ class GordonRouter:
 
         except KeyError:
             msg = (f'Message "{event_msg}" has an unknown phase: '
-                   f'"{event_msg.phase}". Dropping message.')
+                   f'"{event_msg.phase}", routing to "cleanup".')
             logging.error(msg)
             next_phase = 'cleanup'
         return next_phase
@@ -132,11 +113,15 @@ class GordonRouter:
             next_phase = self._get_next_phase(event_msg)
 
         event_msg.update_phase(next_phase)
-        next_plugin_name = self.PHASE_TO_PLUGIN_MAPPER[next_phase]
-        plugin = self.plugins[next_plugin_name]
+        next_plugin = self.phase_plugin_map.get(next_phase)
+        if next_phase in self.FINAL_PHASES and not next_plugin:
+            msg = (f'Dropping message"{event_msg}", final phase "{next_phase}"'
+                   'not implemented.')
+            logging.debug(msg)
+            return
 
         try:
-            await plugin.handle_message(event_msg)
+            await next_plugin.handle_message(event_msg)
             # don't add a successfully dropped message back onto channel
             if next_phase not in self.FINAL_PHASES:
                 msg = f'Adding message "{event_msg}" to success channel.'
@@ -144,7 +129,8 @@ class GordonRouter:
                 await self.success_channel.put(event_msg)
 
         except Exception as e:
-            msg = f'Dropping message "{event_msg}" due to exception: "{e}"'
+            msg = (f'Routing message "{event_msg}" to cleanup due to exception:'
+                   f' "{e}"')
             event_msg.append_to_history(msg, event_msg.phase)
             logging.warn(msg, exc_info=e)
             await self._route(event_msg, 'cleanup')

--- a/gordon/router.py
+++ b/gordon/router.py
@@ -80,11 +80,11 @@ class GordonRouter:
     def _get_next_phase(self, event_msg):
         try:
             next_phase = self.phase_route[event_msg.phase]
-            msg = f'Routing message {event_msg} to phase "{next_phase}".'
+            msg = f'Routing message {event_msg.msg_id} to "{next_phase}".'
             logging.debug(msg)
 
         except KeyError:
-            msg = (f'Message "{event_msg}" has an unknown phase: '
+            msg = (f'Message "{event_msg.msg_id}" has an unknown phase: '
                    f'"{event_msg.phase}", routing to "cleanup".')
             logging.error(msg)
             next_phase = 'cleanup'
@@ -92,8 +92,8 @@ class GordonRouter:
 
     async def _route(self, event_msg, next_phase=None):
         if not interfaces.IEventMessage.providedBy(event_msg):
-            msg = (f'Ignoring message "{event_msg}". Does not correctly '
-                   'implement `IEventMessage`.')
+            msg = (f'Ignoring message "{event_msg.msg_id}". Does not correctly'
+                   ' implement `IEventMessage`.')
             logging.warn(msg)
             return
 
@@ -103,8 +103,8 @@ class GordonRouter:
         event_msg.update_phase(next_phase)
         next_plugin = self.phase_plugin_map.get(next_phase)
         if next_phase in self.FINAL_PHASES and not next_plugin:
-            msg = (f'Dropping message"{event_msg}", final phase "{next_phase}"'
-                   'not implemented.')
+            msg = (f'Dropping message"{event_msg.msg_id}", final phase '
+                   f'"{next_phase}" not implemented.')
             logging.debug(msg)
             return
 

--- a/gordon/router.py
+++ b/gordon/router.py
@@ -51,6 +51,7 @@ class GordonRouter:
         be removed entirely from all interface definitions.
 
     Args:
+        phase_route (dict(str, str)): The route messages should follow.
         success_channel (asyncio.Queue): A sink for successfully
             processed :class:`gordon.interfaces.IEventMessage` s.
         error_channel (asyncio.Queue): A sink for
@@ -62,24 +63,11 @@ class GordonRouter:
     #              iterations of gordon.
     FINAL_PHASES = ('cleanup',)
 
-    def __init__(self, success_channel, error_channel, plugins):
+    def __init__(self, phase_route, success_channel, error_channel, plugins):
         self.success_channel = success_channel
         self.error_channel = error_channel
         self.phase_plugin_map = self._get_phase_plugin_map(plugins)
-        self.phase_route = self._setup_phase_route()
-
-    # TODO (lynn): Ideally this is configurable/extendable in future
-    #              iterations of gordon.
-    def _setup_phase_route(self):
-        route = {
-            'consume': 'publish',
-            'publish': 'cleanup',
-            'cleanup': 'cleanup',
-        }
-        if 'enrich' in self.phase_plugin_map:
-            route['consume'] = 'enrich'
-            route['enrich'] = 'publish'
-        return route
+        self.phase_route = phase_route
 
     def _get_phase_plugin_map(self, plugins):
         phase_map = {p.phase: p for p in plugins}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -129,6 +129,11 @@ def loaded_config():
             'logging': {
                 'level': 'debug',
                 'handlers': ['stream'],
+            },
+            'route': {
+                'consume': 'enrich',
+                'enrich': 'publish',
+                'publish': 'cleanup'
             }
         },
         'xyz': {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,66 +28,64 @@ import zope.interface
 from gordon import interfaces
 
 
-PLUGIN_NAMES = ['event_consumer', 'enricher', 'publisher', 'runnable']
+PLUGIN_NAMES = [
+    'event_consumer',
+    'enricher',
+    'publisher',
+    'runnable'
+]
 # what plugins are registered as within `setup.py:setup.entry_points`
 REGISTERED_PLUGINS = ['xyz.' + p for p in PLUGIN_NAMES]
 ACTIVE_NAMES = PLUGIN_NAMES[:3]
 REGISTERED_ACTIVE_PLUGINS = REGISTERED_PLUGINS[:3]
 
 
-@zope.interface.implementer(interfaces.IEventConsumerClient)
+@zope.interface.implementer(interfaces.IRunnable, interfaces.IMessageHandler)
 class EventConsumerStub:
-    def __init__(self, config, success_channel, error_channel, metrics=None):
+    start_phase = 'consume'
+    phase = 'cleanup'
+
+    def __init__(self, config, success_channel, error_channel, metrics=None,
+                 **kwargs):
         self.config = config
         self.success_channel = success_channel
         self.error_channel = error_channel
         self._mock_run_count = 0
-        self._mock_cleanup_count = 0
+        self._mock_handle_message_count = 0
+
+    async def handle_message(self, event_msg):
+        await asyncio.sleep(0)
+        self._mock_handle_message_count += 1
 
     async def run(self):
         await asyncio.sleep(0)
         self._mock_run_count += 1
 
-    async def cleanup(self, event_msg):
-        await asyncio.sleep(0)
-        self._mock_cleanup_count += 1
-
     async def shutdown(self):
         pass
 
 
-@zope.interface.implementer(interfaces.IEnricherClient)
+@zope.interface.implementer(interfaces.IMessageHandler)
 class EnricherStub:
-    def __init__(self, config, success_channel, error_channel, metrics=None):
-        self.config = config
-        self.success_channel = success_channel
-        self.error_channel = error_channel
-        self._mock_process_count = 0
+    phase = 'enrich'
 
-    async def process(self, event_msg):
+    def __init__(self, config, metrics=None, **kwargs):
+        self.config = config
+        self._mock_handle_message_count = 0
+
+    async def handle_message(self, event_msg):
         await asyncio.sleep(0)
-        self._mock_process_count += 1
+        self._mock_handle_message_count += 1
 
     async def shutdown(self):
         pass
 
 
-@zope.interface.implementer(interfaces.IPublisherClient)
-class PublisherStub:
-    def __init__(self, config, success_channel, error_channel, metrics=None):
-        self.config = config
-        self.success_channel = success_channel
-        self.error_channel = error_channel
-        self._mock_publish_changes_count = 0
-
-    async def publish_changes(self, event_msg):
-        await asyncio.sleep(0)
-        self._mock_publish_changes_count += 1
-
-    async def shutdown(self):
-        pass
+class PublisherStub(EnricherStub):
+    phase = 'publish'
 
 
+@zope.interface.implementer(interfaces.IRunnable)
 class GenericStub:
     def __init__(self, config, success_channel, error_channel, metrics=None):
         self.config = config
@@ -124,7 +122,9 @@ def loaded_config():
     return {
         'core': {
             'plugins': [
-                'xyz.event_consumer', 'xyz.enricher', 'xyz.publisher'],
+                'xyz.event_consumer',
+                'xyz.enricher',
+                'xyz.publisher'],
             'debug': True,
             'logging': {
                 'level': 'debug',
@@ -142,7 +142,7 @@ def loaded_config():
             },
             'publisher': {
                 'c_key': 'c_value',
-            },
+            }
         }
     }
 

--- a/tests/unit/fixtures/test-gordon.toml
+++ b/tests/unit/fixtures/test-gordon.toml
@@ -4,6 +4,11 @@
 plugins = ["xyz.event_consumer", "xyz.enricher", "xyz.publisher"]
 debug = true
 
+[core.route]
+consume = "enrich"
+enrich = "publish"
+publish = "cleanup"
+
 [core.logging]
 level = "debug"
 handlers = ["stream"]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -32,7 +32,6 @@ def test_load_config(tmpdir, suffix, config_file, loaded_config):
     conf_file = tmpdir.mkdir('config').join('gordon{}.toml'.format(suffix))
     conf_file.write(config_file)
     config = main._load_config(root=conf_file.dirpath())
-
     assert loaded_config == config
 
 

--- a/tests/unit/test_plugins_loader.py
+++ b/tests/unit/test_plugins_loader.py
@@ -58,7 +58,7 @@ def plugin_config():
             'a_key': 'a_value',
             'b_key': 'b_value',
             'c_key': 'c_value',
-        },
+        }
     }
 
 
@@ -70,7 +70,7 @@ def exp_inited_plugins(plugin_config, plugin_kwargs):
         conftest.EnricherStub(
             plugin_config['xyz.enricher'], **plugin_kwargs),
         conftest.PublisherStub(
-            plugin_config['xyz.publisher'], **plugin_kwargs),
+            plugin_config['xyz.publisher'], **plugin_kwargs)
     ]
 
 

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -22,10 +22,11 @@ from gordon import router
 
 
 @pytest.fixture()
-def router_inst(inited_plugins, plugin_kwargs):
+def router_inst(loaded_config, inited_plugins, plugin_kwargs):
     inited_plugins.pop('runnable')
+    route_config = loaded_config['core']['route']
     router_inst = router.GordonRouter(
-            plugins=inited_plugins.values(), **plugin_kwargs)
+            route_config, plugins=inited_plugins.values(), **plugin_kwargs)
     return router_inst
 
 
@@ -78,7 +79,7 @@ def test_init_router(has_enricher, inited_plugins, plugin_kwargs):
         inited_plugins.pop('enricher')
 
     router_inst = router.GordonRouter(
-        plugins=inited_plugins.values(), **plugin_kwargs)
+        exp_phase_route, plugins=inited_plugins.values(), **plugin_kwargs)
 
     assert exp_phase_route == router_inst.phase_route
     for phase, plugin in router_inst.phase_plugin_map.items():

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -24,7 +24,8 @@ from gordon import router
 @pytest.fixture()
 def router_inst(inited_plugins, plugin_kwargs):
     inited_plugins.pop('runnable')
-    router_inst = router.GordonRouter(plugins=inited_plugins, **plugin_kwargs)
+    router_inst = router.GordonRouter(
+            plugins=inited_plugins.values(), **plugin_kwargs)
     return router_inst
 
 
@@ -54,26 +55,34 @@ def event_msg(mocker):
     return msg
 
 
-@pytest.mark.parametrize('enricher', [True, False])
-def test_init_router(enricher, inited_plugins, plugin_kwargs):
-    inited_plugins.pop('runnable')
-    if not enricher:
-        inited_plugins.pop('enricher')
-
-    router_inst = router.GordonRouter(plugins=inited_plugins, **plugin_kwargs)
-
+@pytest.mark.parametrize('has_enricher', [True, False])
+def test_init_router(has_enricher, inited_plugins, plugin_kwargs):
     exp_phase_route = {
         'consume': 'publish',
         'publish': 'cleanup',
         'cleanup': 'cleanup'
     }
-    if enricher:
+
+    exp_phase_map = {
+        'consume': interfaces.IRunnable,
+        'publish': interfaces.IMessageHandler,
+        'cleanup': interfaces.IMessageHandler
+    }
+
+    inited_plugins.pop('runnable')
+    if has_enricher:
         exp_phase_route['consume'] = 'enrich'
         exp_phase_route['enrich'] = 'publish'
+        exp_phase_map['enrich'] = interfaces.IMessageHandler
+    else:
+        inited_plugins.pop('enricher')
+
+    router_inst = router.GordonRouter(
+        plugins=inited_plugins.values(), **plugin_kwargs)
 
     assert exp_phase_route == router_inst.phase_route
-    for _, plugin in router_inst.plugins.items():
-        assert hasattr(plugin, 'handle_message')
+    for phase, plugin in router_inst.phase_plugin_map.items():
+        assert exp_phase_map[phase].providedBy(plugin)
 
 
 @pytest.mark.parametrize('current_phase,exp_next_phase', (
@@ -96,6 +105,7 @@ def test_get_next_phase(current_phase, exp_next_phase, router_inst, event_msg,
 ))
 async def test_route(raises, exp_call_count, exp_log_count, event_msg,
                      router_inst, caplog, monkeypatch):
+
     mock_process_call_count = 0
     mock_process_call_args = []
 
@@ -109,7 +119,7 @@ async def test_route(raises, exp_call_count, exp_log_count, event_msg,
             raise Exception('foo')
 
     monkeypatch.setattr(
-        router_inst.plugins['enricher'], 'handle_message', mock_process)
+        router_inst.phase_plugin_map['enrich'], 'handle_message', mock_process)
 
     await router_inst._route(event_msg)
 
@@ -117,8 +127,18 @@ async def test_route(raises, exp_call_count, exp_log_count, event_msg,
     assert [((event_msg,), {})] == mock_process_call_args
     assert 1 == event_msg._mock_append_to_history
     assert exp_log_count == len(caplog.records)
-    actual_count = router_inst.plugins['event_consumer']._mock_cleanup_count
+    actual_count = \
+        router_inst.phase_plugin_map['cleanup']._mock_handle_message_count
     assert exp_call_count == actual_count
+
+
+@pytest.mark.asyncio
+async def test_route_no_phase_no_cleanup(event_msg, router_inst, caplog):
+    del(router_inst.phase_plugin_map['cleanup'])
+    event_msg.phase = 'blahblah'  # doesnt exist
+
+    await router_inst._route(event_msg)
+    assert 2 == len(caplog.records)  # unknown phase, drop
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
- Remove IEventConsumerClient, IEnricherClient, IPublisherClient
- Add IRunnable, IMessageHandler
- Remove special message_handler logic from router
- Remove specific plugin type knowledge from router (build map dynamically)
- Allow route to be configured
- Require IEventMessags to have `phase` to route and `msg_id` for logging
- Update tests to reflect above changes

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:
@spotify/alf Please review.  This commit was started to add unifying `handle_message` methods to the plugin definitions. After that change, it became apparent that specific plugins weren't needed and generic plugin definitions were sufficient to run with Gordon.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
- Remove IEventConsumerClient, IEnricherClient, IPublisherClient
- Add IRunnable, IMessageHandler
- Add route configuration requirement
- Require IEventMessage to have `phase` and `msg_id`
```
