### PR TITLE
Add metrics instrumentation to router

### DIFF
--- a/gordon/main.py
+++ b/gordon/main.py
@@ -157,9 +157,9 @@ def _gather_plugins_by_type(plugins, debug):
     return runnable_plugins, message_handling_plugins
 
 
-def _setup_router(config, plugins, success_channel, error_channel):
+def _setup_router(config, plugins, metrics, success_channel, error_channel):
     msg_router = router.GordonRouter(
-        config, success_channel, error_channel, plugins)
+        config, success_channel, error_channel, plugins, metrics)
     return msg_router
 
 
@@ -177,7 +177,6 @@ def run(config_root):
     config = setup(os.path.abspath(config_root))
     debug_mode = config.get('core', {}).get('debug', False)
 
-    # TODO: initialize a metrics object - either here or within `load_plugins`
     channels = {
         'success_channel': asyncio.Queue(),
         'error_channel': asyncio.Queue(),
@@ -195,7 +194,8 @@ def run(config_root):
     runnables, message_handlers = _gather_plugins_by_type(plugins, debug_mode)
 
     route_config = config.get('core', {}).get('route', {})
-    msg_router = _setup_router(route_config, message_handlers, **channels)
+    msg_router = _setup_router(
+        route_config, message_handlers, metrics, **channels)
 
     logging.info(f'Starting gordon v{version}...')
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This gives default metrics, no matter which plugins are used/installed. Because of that, the metric names are prefixed with `router-`. Metrics added:

- Messages consumed (to be routed if valid interface provider)
- Messages dropped (either invalid message interface provider, or error’ed out)
- Messages in flight (a gauge that’s updated each time a message is routed)
- Duration of messages in flight (consume->cleanup)
- Messages successfully completed route from start to finish (consume -> publish)
- Messages routed per phase (i.e. from consume to publish, from enrich to publish, etc)

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

Depending on which gets in first, either this or #25 will need to rebase.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add basic metrics to core router.
```
