### PR TITLE
Add metric logger MetricRelay implementation

### DIFF
--- a/gordon.toml
+++ b/gordon.toml
@@ -3,4 +3,9 @@
 level = "debug"
 handlers = ["syslog"]
 
-# Extension Config
+[core]
+metrics = "metrics-logger"
+
+[metrics-logger]
+log_level = "info"
+time_unit = 1

--- a/gordon/metrics/log.py
+++ b/gordon/metrics/log.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Gordon ships with a default IMetricRelay implementation, which
+outputs metrics to the application logger using the standard
+library `logging` module.
+
+This implementation is used by default if no other IMetricRelay
+implementation is loaded and chosen.
+
+The default configuration that can be overriden is shown below.
+
+.. code-block:: ini
+
+    [metrics-logger]
+    # One of the log levels available from the stdlib logging module.
+    log_level = 'info'
+    # A scaling factor for timing (see: LogTimer)
+    time_unit = 1
+"""
+
+import collections
+import logging
+import time
+
+import zope.interface
+
+from gordon import interfaces
+
+
+@zope.interface.implementer(interfaces.ITimer)
+class LogTimer:
+    """Timer that outputs metrics to the logger.
+
+    Args:
+        metric (dict): Metric to output.
+        logger (.LoggerAdapter): Object used for outputting metrics.
+        time_unit (number): (optional) Scale time unit for use with
+            time.perf_counter(), for example: 1E9 to send nanoseconds.
+    """
+    def __init__(self, metric, logger, time_unit=1):
+        self.metric = metric
+        self.logger = logger
+        self.time_unit = time_unit
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.stop()
+
+    async def start(self):
+        """Start the timer."""
+        self._start_time = time.perf_counter()
+
+    async def stop(self):
+        """Stop the timer and output the time delta to the logger."""
+        time_elapsed = (
+            time.perf_counter() - self._start_time) * self.time_unit
+        self.metric['value'] = time_elapsed
+        self.logger.log(self.metric)
+
+
+class LoggerAdapter:
+    """Configurable adapter that formats and outputs metrics.
+
+    Args:
+        level (str): Log level at which to output metric.
+    """
+    LOGFMT = '[{metric_name}] value: {value}'
+
+    def __init__(self, level):
+        self.level = getattr(logging, level.upper())
+        self._logger = logging.getLogger('gordon.metrics-logger')
+
+    def log(self, metric):
+        """Format and output metric.
+
+        Args:
+            metric (dict): Complete metric.
+        """
+        message = self.LOGFMT.format(**metric)
+        if metric['context']:
+            message += ' context: {context}'.format(context=metric['context'])
+        self._logger.log(self.level, message)
+
+
+@zope.interface.implementer(interfaces.IMetricRelay)
+class LogRelay:
+    """Manage metrics that get output to a logger.
+
+    Args:
+        config (dict): Required keys:
+            level (str): Log level of metrics log messages.
+            time_unit (number): (optional) Scale time unit for use with
+                LogTimer, for example: 1E9 to send nanoseconds.
+    """
+    def __init__(self, config):
+        level = config.get('log_level', 'info')
+        self.time_unit = config.get('time_unit', 1)
+        self.logger = LoggerAdapter(level)
+        self.counters = collections.defaultdict(int)
+
+    def _create_metric(self, metric_name, value, context, **kwargs):
+        context = context or {}
+
+        return {
+            'metric_name': metric_name,
+            'value': value,
+            'context': context
+        }
+
+    async def incr(self, metric_name, value=1, context=None, **kwargs):
+        """Increase a metric counter by ``value`` and output result.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (number): (optional) Value with which to increase the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'remote-host': '1.2.3.4'}
+        """
+        self.counters[metric_name] += value
+        await self.set(metric_name, self.counters[metric_name], context,
+                       **kwargs)
+
+    def timer(self, metric_name, context=None, **kwargs):
+        """Create a LogTimer.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'unit': 'milliseconds'}
+        """
+        metric = self._create_metric(metric_name, None, context, **kwargs)
+        return LogTimer(metric, self.logger, self.time_unit)
+
+    async def set(self, metric_name, value, context=None, **kwargs):
+        """Output ``metric_name`` with ``value``.
+
+        Args:
+            metric_name (str): Identifier of the metric.
+            value (number): (optional) Value of the metric.
+            context (dict): (optional) Additional key-value pairs which further
+                describe the metric, for example: {'app-version': '1.5.4'}
+        """
+        metric = self._create_metric(metric_name, value, context, **kwargs)
+        self.logger.log(metric)
+
+    async def cleanup(self):
+        """Not used."""
+        pass

--- a/gordon/plugins_loader.py
+++ b/gordon/plugins_loader.py
@@ -60,6 +60,7 @@ import pkg_resources
 
 from gordon import exceptions
 from gordon.metrics import ffwd
+from gordon.metrics import log
 
 
 PLUGIN_NAMESPACE = 'gordon.plugins'
@@ -188,11 +189,12 @@ def _gather_installed_plugins():
 
 
 def _get_metrics_plugin(config, installed_plugins):
-    metrics_provider = config.get('core', {}).get('metrics')
-    if not metrics_provider:
-        return
-
+    metrics_provider = config.get('core', {}).get('metrics', 'metrics-logger')
     metrics_config = config.get(metrics_provider, {})
+
+    if metrics_provider == 'metrics-logger':
+        return log.LogRelay(metrics_config)
+
     if metrics_provider == 'ffwd':
         return ffwd.SimpleFfwdRelay(metrics_config)
 

--- a/tests/unit/metrics/test_log.py
+++ b/tests/unit/metrics/test_log.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numbers
+
+import pytest
+
+from gordon.metrics import log
+
+
+@pytest.mark.parametrize('context,context_str', [
+    ({'source': 'external'}, ' context: {\'source\': \'external\'}'),
+    ({}, '')
+])
+def test_logger_adapter_log_outputs_message(caplog, context, context_str):
+    """Metric is formatted and output to log."""
+    logger_adapter = log.LoggerAdapter('INFO')
+    metric = {
+        'metric_name': 'events',
+        'value': 12.12,
+        'context': context
+        }
+    logger_adapter.log(metric)
+    assert 1 == len(caplog.records)
+    expected_log = '[events] value: 12.12' + context_str
+    assert expected_log == caplog.records[0].msg
+
+
+@pytest.fixture
+def mock_logger_adapter(mocker):
+    return mocker.Mock(log.LoggerAdapter)
+
+
+@pytest.fixture
+def log_timer(mock_logger_adapter):
+    metric = {'metric_name': 'test-metric', 'value': 13.05, 'context': {}}
+    return log.LogTimer(metric, mock_logger_adapter, 1)
+
+
+@pytest.mark.asyncio
+async def test_log_timer_manual(log_timer):
+    """Times when using start/stop interface."""
+
+    await log_timer.start()
+    assert isinstance(log_timer._start_time, numbers.Number)
+
+    await log_timer.stop()
+    assert 1 == log_timer.logger.log.call_count
+    actual_metric = log_timer.logger.log.mock_calls[0][1][0]
+    assert 'test-metric' == actual_metric['metric_name']
+    assert {} == actual_metric['context']
+    assert 0 < actual_metric['value']
+
+
+@pytest.mark.asyncio
+async def test_log_timer_as_context_manager(log_timer):
+    """Times when using as a context manager."""
+    async with log_timer as t:
+        assert isinstance(t._start_time, numbers.Number)
+    actual_metric = log_timer.logger.log.mock_calls[0][1][0]
+    assert 1 == log_timer.logger.log.call_count
+    assert 'test-metric' == actual_metric['metric_name']
+    assert {} == actual_metric['context']
+    assert 0 < actual_metric['value']
+
+
+@pytest.fixture
+def relay_config():
+    return {
+        'time_unit': 1,
+        'log_level': 'info',
+    }
+
+
+@pytest.mark.parametrize('name,val,context', [
+    ('a-metric', 12, None),
+    ('nother-metric', 0.0003, {'source': 'internal'}),
+])
+def test_logrelay_create_metric(relay_config, name, val, context):
+    """Create a metric dictionary."""
+    relay = log.LogRelay(relay_config)
+    actual = relay._create_metric(name, val, context=context)
+
+    expected = {
+        'metric_name': name,
+        'value': val,
+        'context': context or {}
+    }
+    assert expected == actual
+
+
+@pytest.fixture
+def log_relay_inst(monkeypatch, mocker, relay_config):
+    logger_mock = mocker.Mock(log.LoggerAdapter)
+    monkeypatch.setattr(log, 'LoggerAdapter', logger_mock)
+    return log.LogRelay(relay_config)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('context', [
+    {'source': 'perimiter'},
+    None
+])
+async def test_logrelay_incr(log_relay_inst, context):
+    """Initializes and outputs metrics to logger."""
+    expected_metric = log_relay_inst._create_metric('requests-recv', 601,
+                                                    context=context)
+    await log_relay_inst.incr('requests-recv', 601, context=context)
+
+    log_relay_inst.logger.log.assert_called_once_with(expected_metric)
+
+
+@pytest.mark.asyncio
+async def test_logrelay_incr_accumulation(mocker, log_relay_inst):
+    """MetricRelay.incr accumulates values."""
+    base_value = 441
+    incr = 10
+    expected_metric = log_relay_inst._create_metric('requests-recv',
+                                                    base_value, context=None)
+    expected_2nd_metric = log_relay_inst._create_metric(
+        'requests-recv', base_value + incr, context=None)
+    await log_relay_inst.incr('requests-recv', base_value)
+    await log_relay_inst.incr('requests-recv', incr)
+
+    assert base_value + incr == log_relay_inst.counters['requests-recv']
+    expected_calls = [
+        mocker.call(expected_metric),
+        mocker.call(expected_2nd_metric)
+    ]
+    log_relay_inst.logger.log.assert_has_calls(expected_calls)
+
+
+def test_logrelay_timer(log_relay_inst):
+    """Initialize and return a LogTimer object."""
+    expected_metric = log_relay_inst._create_metric('latency', None,
+                                                    context=None)
+    timer = log_relay_inst.timer('latency')
+    assert isinstance(timer, log.LogTimer)
+    assert expected_metric == timer.metric
+    assert timer.logger == log_relay_inst.logger
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('context', [
+    {'version': 'dev0'},
+    None
+])
+async def test_logrelay_set(log_relay_inst, context):
+    """Output single metric to logger."""
+    expected_metric = log_relay_inst._create_metric('latency', 451,
+                                                    context=context)
+    await log_relay_inst.set('latency', 451, context=context)
+
+    log_relay_inst.logger.log.assert_called_once_with(expected_metric)
+
+
+@pytest.mark.asyncio
+async def test_cleanup(log_relay_inst):
+    """Implemented, but a noop."""
+    assert await log_relay_inst.cleanup() is None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This PR implements the default metric relay, which outputs metrics to a logger.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

This PR has addressed all the feedback from #23 with [one piece of feedback](https://github.com/spotify/gordon/pull/23#discussion_r194443794) waiting for more input/opinions. 

This PR does not include the changes needed to make the metrics logger the default logger.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add metric logger.
```

@spotify/alf 