### PR TITLE
Add basic graceful shutdown

### DIFF
--- a/gordon/main.py
+++ b/gordon/main.py
@@ -35,6 +35,7 @@ Example:
 import asyncio
 import logging
 import os
+import signal
 
 import click
 import toml
@@ -45,6 +46,23 @@ from gordon import exceptions
 from gordon import interfaces
 from gordon import plugins_loader
 from gordon import router
+
+
+async def shutdown(sig, loop):
+    """Gracefully cancel current tasks when app receives a shutdown signal."""
+    logging.info(f'Received exit signal {sig.name}...')
+    tasks = [task for task in asyncio.Task.all_tasks() if task is not
+             asyncio.tasks.Task.current_task()]
+
+    for task in tasks:
+        logging.debug(f'Cancelling task: {task}')
+        task.cancel()
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    logging.debug(f'Done awaiting cancelled tasks, results: {results}')
+
+    loop.stop()
+    logging.info('Shutdown complete.')
 
 
 def _load_config(root=''):
@@ -181,11 +199,19 @@ def run(config_root):
 
     logging.info(f'Starting gordon v{version}...')
     loop = asyncio.get_event_loop()
+
+    # Register shutdown to signals
+
+    for signame in (signal.SIGHUP, signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(
+            signame, lambda: asyncio.ensure_future(shutdown(signame, loop)))
+
     try:
         loop.create_task(_run(runnables, msg_router, debug_mode))
         loop.run_forever()
+
     finally:
-        loop.stop()
+        loop.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

Adds a basic graceful shutdown hook when the service receives a `SIGINT`, `SIGTERM`, or a `SIGHUP` signal. All it does is just cancels the outstanding asyncio tasks.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

For where I arrived at this approach, I found [this SO answer](https://stackoverflow.com/a/43810272) on awaiting cancelled tasks (and not just cancelling them), used [this example approach](https://gist.github.com/nvgoldin/30cea3c04ee0796ebd0489aa62bcf00a) combined [with this one](https://stackoverflow.com/questions/23313720/asyncio-how-can-coroutines-be-used-in-signal-handlers).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a basic graceful shutdown mechanism.
```

cc @spotify/alf 
