### PR TITLE
Respect ulogger configuration

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -69,6 +69,17 @@ core.logging
 
         If ``stackdriver`` is selected, ``ulogger[stackdriver]`` needs to be installed as its dependencies are not installed by default.
 
+Other key-value pairs as supported by `ulogger`_ will be passed into the configured handlers. For example:
+
+.. code-block:: ini
+
+    [core.logging]
+    level = "info"
+    handlers = ["syslog"]
+    address = ["10.99.0.1", "514"]
+    format = "%(created)f %(levelno)d %(message)s"
+    date_format = "%Y-%m-%dT%H:%M:%S"
+
 
 core.route
 ~~~~~~~~~~
@@ -83,3 +94,6 @@ plugin.
     [core.route]
     start_phase = "phase2"
     phase2 = "phase3"
+
+
+.. _`ulogger`: https://github.com/spotify/ulogger

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -12,6 +12,10 @@ publish = "cleanup"
 [core.logging]
 level = "info"
 handlers = ["syslog"]
+format = "%(created)f %(levelno)d %(message)s"
+date_format = "%Y-%m-%dT%H:%M:%S"
+address = ["10.99.0.1", "514"]
+
 
 # Plugin Config
 ["foo"]

--- a/gordon/main.py
+++ b/gordon/main.py
@@ -95,12 +95,14 @@ def setup(config_root=''):
     """
     config = _load_config(root=config_root)
 
-    logging_config = config.get('core', {}).get('logging', {})
-    log_level = logging_config.get('level', 'INFO').upper()
-    log_handlers = logging_config.get('handlers') or ['syslog']
+    logging_config = config.get('core', {}).get('logging', {}).copy()
+
+    log_level = logging_config.pop('level', 'INFO').upper()
+    log_handlers = logging_config.pop('handlers', ['syslog'])
 
     ulogger.setup_logging(
-        progname='gordon', level=log_level, handlers=log_handlers)
+        progname='gordon', level=log_level, handlers=log_handlers,
+        **logging_config)
 
     return config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==6.7
 setuptools==38.2.5
 toml==0.9.3.1
-ulogger==1.0.1
+ulogger==1.0.2
 zope.interface==4.4.3
 async-dns==1.0.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -129,6 +129,8 @@ def loaded_config():
             'logging': {
                 'level': 'debug',
                 'handlers': ['stream'],
+                'format': '%(created)f %(levelno)d %(message)s',
+                'date_format': '%Y-%m-%dT%H:%M:%S',
             },
             'route': {
                 'consume': 'enrich',

--- a/tests/unit/fixtures/test-gordon.toml
+++ b/tests/unit/fixtures/test-gordon.toml
@@ -12,6 +12,8 @@ publish = "cleanup"
 [core.logging]
 level = "debug"
 handlers = ["stream"]
+format = "%(created)f %(levelno)d %(message)s"
+date_format = "%Y-%m-%dT%H:%M:%S"
 
 # Plugin Config
 [xyz]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -77,8 +77,12 @@ def test_setup(tmpdir, mocker, monkeypatch, config_file, loaded_config):
 
     assert loaded_config == config
 
+    exp_kwargs = {
+        'format': '%(created)f %(levelno)d %(message)s',
+        'date_format': '%Y-%m-%dT%H:%M:%S',
+    }
     ulogger_mock.setup_logging.assert_called_once_with(
-        progname='gordon', level='DEBUG', handlers=['stream'])
+        progname='gordon', level='DEBUG', handlers=['stream'], **exp_kwargs)
 
 
 #####


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

The `ulogger` defaults for syslog, stream, and stackdriver may not be good for `gordon` users. This patch passes the logging configuration down to `ulogger` for handling so we can override defaults.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for ulogger configuration
```

cc @spotify/alf 