### PR TITLE
Use deep merge on config files

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -14,7 +14,7 @@ An example of a ``gordon.toml`` file:
     :language: ini
 
 
-You may choose to have a ``gordon-user.toml`` file for development. Any top-level key will override what's found in ``gordon.toml``.
+You may choose to have a ``gordon-user.toml`` file for development. All tables are deep merged into ``gordon.toml``, to limit the amount of config duplication needed. For example, you can override ``core.debug`` without having to redeclare which plugins you'd like to run.
 
 .. code-block:: ini
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This PR changes the way multiple config files. Due to the highly nested nature of Gordon configs I suspect this is what we intended to have from the start. 

Example of the difference below:
```
# gordon.toml
[core.logging]
level = "info"
handlers = ["syslog"]
fmt = "%(asctime)s.%(msecs)03dZ gordon[%(process)d]: %(message)s"

# gordon-user.toml
[core.logging]
level = "error"

# final loaded config before PR
{'core': {'logging': {'level' : 'error'}}}

# final loaded config after PR
{'core': {'logging': {'level' : 'error', 'handlers':['syslog'], 'fmt': '%(asctime)s.%(msecs)03dZ gordon[%(process)d]: %(message)s'}}}
```


**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:
This is based strongly off of https://github.com/spotify/gordon-janitor/pull/17 and https://github.com/spotify/gordon-janitor/pull/20

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Deep merge user config file.
```
@spotify/alf 