### PR TITLE
Correctly handle plugin loader errors

### DIFF
--- a/gordon/main.py
+++ b/gordon/main.py
@@ -195,10 +195,9 @@ def run(config_root):
     }
     plugin_names, plugins, errors, plugin_kwargs = plugins_loader.load_plugins(
         config, plugin_kwargs)
-    if errors:
-        for err_plugin, exc in errors:
-            base_msg = 'Plugin was not loaded: {err_plugin}'
-            _log_or_exit_on_exceptions(base_msg, exc, debug=debug_mode)
+    for err_plugin, exc in errors:
+        base_msg = f'Plugin was not loaded: {err_plugin}'
+        _log_or_exit_on_exceptions(base_msg, exc, debug=debug_mode)
 
     if plugin_names:
         logging.info(f'Loaded {len(plugin_names)} plugins: {plugin_names}.')


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->
**What this PR does / why we need it**:
Fixes how we handle plugin loader errors. Copied from https://github.com/spotify/gordon-janitor/commit/58841fa357db20d4f6989c4491598511ee559ce4.  Currently we see the following, which makes it hard to identify the plugin 
```
2019-03-08T22:02:29.358Z gordon[1]: Plugin was not loaded: {err_plugin}
Traceback (most recent call last):
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon/plugins_loader.py", line 87, in _init_plugins
    plugin_object = plugin_class(plugin_config, **kwargs)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_internal/plugins/service/__init__.py", line 44, in get_gdns_publisher
    return builder.build_publisher()
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_internal/plugins/service/gdns_publisher.py", line 84, in build_publisher
    _sli_dns_resolvers._start_scheduler()
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_internal/clients/sli_reporter.py", line 164, in _start_scheduler
    scheduler = aioscheduler.AsyncIOScheduler()
  File "/usr/src/app/.venv/lib/python3.6/site-packages/apscheduler/schedulers/base.py", line 83, in __init__
    self.configure(gconfig, **options)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/apscheduler/schedulers/base.py", line 122, in configure
    self._configure(config)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/apscheduler/schedulers/asyncio.py", line 48, in _configure
    super(AsyncIOScheduler, self)._configure(config)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/apscheduler/schedulers/base.py", line 694, in _configure
    self.timezone = astimezone(config.pop('timezone', None)) or get_localzone()
  File "/usr/src/app/.venv/lib/python3.6/site-packages/tzlocal/unix.py", line 131, in get_localzone
    _cache_tz = _get_localzone()
  File "/usr/src/app/.venv/lib/python3.6/site-packages/tzlocal/unix.py", line 125, in _get_localzone
    raise pytz.UnknownTimeZoneError('Can not find any timezone configuration')
pytz.exceptions.UnknownTimeZoneError: 'Can not find any timezone configuration'
```

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

@spotify/alf

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Correctly handle plugin loader errors
```
